### PR TITLE
fix: resolve CORS policy issue after header modification and re-routing

### DIFF
--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -175,6 +175,15 @@ Http::FilterHeadersStatus CorsFilter::encodeHeaders(Http::ResponseHeaderMap& hea
     return Http::FilterHeadersStatus::Continue;
   }
 
+  // Reinitialize CORS policy, based on current route (may have changed)
+  initializeCorsPolicies();
+
+  // Check whether the current route allows the origin
+  if (!isOriginAllowed(Http::HeaderString(latched_origin_))) {
+    config_->stats().origin_invalid_.inc();
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   headers.setInline(access_control_allow_origin_handle.handle(), latched_origin_);
   if (allowCredentials()) {
     headers.setReferenceInline(access_control_allow_credentials_handle.handle(),


### PR DESCRIPTION
Related issue: https://github.com/alibaba/higress/issues/1769

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fix(cors): re-evaluate CORS policy after header modification and rerouting
Additional Description: This fixes the scenario where CORS policy becomes ineffective after modifying headers and triggering re-routing. The root cause is that CORS filter's decodeHeader phase only executes on initial route match. When headers are modified mid-request (e.g. via header transformation plugin) leading to re-routing, the subsequent route's CORS configuration wasn't being applied.
Risk Level:
Testing: I wrote an integration test, but I don’t know how to test the route change scenario. I haven’t committed the test code yet.
Docs Changes: N/A (Behavioral fix with no API changes)
Release Notes: fix: Ensure CORS policies take effect when requests are re-routed after header modifications
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue] Fixes https://github.com/alibaba/higress/issues/1769
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
