### PR TITLE
golang: add callback method for http plugin config destruction (#38597)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,3 +5,28 @@ bug_fixes:
   change: |
     Fixed a bug where additional :ref:`cookie attributes <envoy_v3_api_msg_config.route.v3.RouteAction.HashPolicy.cookie>`
     are not sent properly to clients.
+# *Changes expected to improve the state of the world and are unlikely to have negative effects*
+removed_config_or_runtime:
+# *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+
+new_features:
+- area: access_log
+  change: |
+    added %RESPONSE_FLAGS_LONG% substitution string, that will output a pascal case string representing the response flags.
+    The output response flags will correspond with %RESPONSE_FLAGS%, only with a long textual string representation.
+- area: extension_discovery_service
+  change: |
+    added ECDS support for :ref:` downstream network filters<envoy_v3_api_field_config.listener.v3.Filter.config_discovery>`.
+- area: access_log
+  change: |
+    Added support for logging upstream connection establishment duration in the
+    :ref:`%COMMON_DURATION% <config_access_log_format_common_duration>` access log
+    formatter operator. The following time points were added: ``%US_CX_BEG%``,
+    ``%US_CX_END%``, ``%US_HS_END%``.
+- area: golang
+  change: |
+    added http golang filter config destroy callback. When a config gets deleted from envoy, the go plugin calls the
+    Destroy function on the config instance. config should implement the new
+    github.com/envoyproxy/envoy/contrib/golang/common/go/api.Config interface, implementing the Destroy function.
+
+deprecated:

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -105,14 +105,22 @@ func (*PassThroughStreamFilter) OnDestroy(DestroyReason) {
 func (*PassThroughStreamFilter) OnStreamComplete() {
 }
 
+type Config interface {
+	// Called when the current config is deleted due to an update or removal of plugin.
+	// You can use this method is you store some resources in the config to be released later.
+	Destroy()
+}
+
 type StreamFilterConfigParser interface {
 	// Parse the proto message to any Go value, and return error to reject the config.
 	// This is called when Envoy receives the config from the control plane.
 	// Also, you can define Metrics through the callbacks, and the callbacks will be nil when parsing the route config.
+	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Parse(any *anypb.Any, callbacks ConfigCallbackHandler) (interface{}, error)
 	// Merge the two configs(filter level config or route level config) into one.
 	// May merge multi-level configurations, i.e. filter level, virtualhost level, router level and weighted cluster level,
 	// into a single one recursively, by invoking this method multiple times.
+	// You can return a config implementing the Config interface if you need fine control over its lifecycle.
 	Merge(parentConfig interface{}, childConfig interface{}) interface{}
 }
 

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -18,6 +18,7 @@ envoy_cc_test(
     ],
     deps = [
         "//contrib/golang/filters/http/source:config",
+        "//contrib/golang/filters/http/test/test_data/destroyconfig:destroyconfig_test_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -9,6 +9,7 @@
 #include "absl/strings/str_format.h"
 #include "contrib/golang/filters/http/source/config.h"
 #include "contrib/golang/filters/http/source/golang_filter.h"
+#include "contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -97,6 +98,35 @@ TEST(GolangFilterConfigTest, GolangFilterWithNilPluginConfig) {
   EXPECT_TRUE(plugin_config.SerializeToString(&str));
   cb(filter_callback);
 
+  cleanup();
+}
+
+TEST(GolangFilterConfigTest, GolangFilterDestroyConfig) {
+  const auto yaml_fmt = R"EOF(
+  library_id: %s
+  library_path: %s
+  plugin_name: %s
+  )EOF";
+
+  const std::string DESTROYCONFIG{"destroyconfig"};
+  auto yaml_string = absl::StrFormat(yaml_fmt, DESTROYCONFIG, genSoPath(), DESTROYCONFIG);
+  envoy::extensions::filters::http::golang::v3alpha::Config proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+
+  auto dso_lib = Dso::DsoManager<Dso::HttpFilterDsoImpl>::load(
+      proto_config.library_id(), proto_config.library_path(), proto_config.plugin_name());
+  auto config_ = new httpDestroyableConfig();
+  config_->plugin_name_ptr = reinterpret_cast<unsigned long long>(DESTROYCONFIG.data());
+  config_->plugin_name_len = DESTROYCONFIG.length();
+  config_->config_ptr = 0;
+  config_->config_len = 0;
+  config_->is_route_config = 0;
+  config_->concurrency = 0;
+  config_->destroyed = 0;
+  auto config_id_ = dso_lib->envoyGoFilterNewHttpPluginConfig(config_);
+  dso_lib->envoyGoFilterDestroyHttpPluginConfig(config_id_, 0);
+  EXPECT_TRUE(config_->destroyed);
+  delete config_;
   cleanup();
 }
 

--- a/contrib/golang/filters/http/test/test_data/BUILD
+++ b/contrib/golang/filters/http/test/test_data/BUILD
@@ -21,6 +21,7 @@ go_binary(
         "//contrib/golang/filters/http/test/test_data/basic",
         "//contrib/golang/filters/http/test/test_data/buffer",
         "//contrib/golang/filters/http/test/test_data/bufferinjectdata",
+        "//contrib/golang/filters/http/test/test_data/destroyconfig",
         "//contrib/golang/filters/http/test/test_data/echo",
         "//contrib/golang/filters/http/test/test_data/metric",
         "//contrib/golang/filters/http/test/test_data/passthrough",

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_test_library(
+    name = "destroyconfig_test_lib",
+    hdrs = [
+        "api.h",
+        "destroyconfig.h",
+    ],
+)
+
+go_library(
+    name = "destroyconfig",
+    srcs = [
+        "api.h",
+        "config.go",
+        "destroyconfig.h",
+    ],
+    cgo = True,
+    importpath = "example.com/test-data/destroyconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//contrib/golang/common/go/api",
+        "//contrib/golang/filters/http/source/go/pkg/http",
+        "@org_golang_google_protobuf//types/known/anypb",
+    ],
+)

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/api.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/api.h
@@ -1,0 +1,1 @@
+../../../../../common/go/api/api.h

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/config.go
@@ -1,0 +1,55 @@
+package destroyconfig
+
+/*
+#cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+#cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
+
+#include "destroyconfig.h"
+
+*/
+import "C"
+import (
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
+	"google.golang.org/protobuf/types/known/anypb"
+	"unsafe"
+)
+
+const Name = "destroyconfig"
+
+func init() {
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, http.PassThroughFactory, &parser{})
+}
+
+var cfgPointer unsafe.Pointer
+
+type config struct {
+	cb api.ConfigCallbackHandler
+}
+
+func (c *config) Destroy() {
+	// call cApi.HttpDefineMetric to store the config pointer
+	c.cb.DefineCounterMetric("")
+	C.envoyGoConfigDestroy(cfgPointer)
+}
+
+type capi struct {
+	api.HttpCAPI
+}
+
+func (c *capi) HttpConfigFinalize(_ unsafe.Pointer) {}
+
+func (c *capi) HttpDefineMetric(cfg unsafe.Pointer, _ api.MetricType, _ string) uint32 {
+	cfgPointer = cfg
+	return 0
+}
+
+type parser struct {
+	api.StreamFilterConfigParser
+}
+
+func (p *parser) Parse(_ *anypb.Any, cb api.ConfigCallbackHandler) (interface{}, error) {
+	http.SetHttpCAPI(&capi{})
+	conf := &config{cb}
+	return conf, nil
+}

--- a/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
+++ b/contrib/golang/filters/http/test/test_data/destroyconfig/destroyconfig.h
@@ -1,0 +1,25 @@
+#pragma once
+// NOLINT(namespace-envoy)
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include "api.h"
+
+#ifdef __cplusplus
+struct httpDestroyableConfig : httpConfig {
+  int destroyed;
+};
+extern "C" {
+#else
+typedef struct {
+  httpConfig c;
+  int destroyed;
+} httpDestroyableConfig;
+#endif
+
+void envoyGoConfigDestroy(void* c) {
+  httpDestroyableConfig* dc = (httpDestroyableConfig*)(c);
+  dc->destroyed = 1;
+};
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/contrib/golang/filters/http/test/test_data/plugins.go
+++ b/contrib/golang/filters/http/test/test_data/plugins.go
@@ -7,6 +7,7 @@ import (
 	_ "example.com/test-data/basic"
 	_ "example.com/test-data/buffer"
 	_ "example.com/test-data/bufferinjectdata"
+	_ "example.com/test-data/destroyconfig"
 	_ "example.com/test-data/echo"
 	_ "example.com/test-data/metric"
 	_ "example.com/test-data/passthrough"


### PR DESCRIPTION
This enables fine grained control over the lifecycle of golang filter config in sync with C++.
Some use cases store states and resources in the config object that needs to be cleaned when config is deleted or renewed. The current design uses a Config interface, to minimise changes and avoid breaking existing code.
I have an alternative design that adds a Destroy function in the StreamFilterConfigParser interface instead of introducing an interface. Let me know what you think, given the current go api is not considered stable and breaking change should be acceptable.

Fixes #38557

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
