### PR TITLE
fix: prevent nil pointer dereference in envoyGoFilterOnHttpData

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -236,7 +236,7 @@ func envoyGoFilterOnHttpHeader(s *C.processState, endStream, headerNum, headerBy
 
 //export envoyGoFilterOnHttpData
 func envoyGoFilterOnHttpData(s *C.processState, endStream, buffer, length uint64) uint64 {
-	state := getState(s)
+	state := getOrCreateState(s)
 
 	req := state.request
 	if req.pInfo.paniced {


### PR DESCRIPTION
## Description
Replace `getState()` with `getOrCreateState()` in `envoyGoFilterOnHttpData` to handle cases where OnHttpData is called before OnHttpHeader.

## Problem
When `envoyGoFilterOnHttpData` is called before `envoyGoFilterOnHttpHeader`, the `s.req` pointer is not yet initialized, causing a nil pointer dereference panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7fe25dce3faf]
```

## Solution
- Changed `getState(s)` to `getOrCreateState(s)` in line 239
- `getOrCreateState` checks if the request exists and creates it if needed, preventing the nil pointer access
- This matches the pattern already used in `envoyGoFilterOnHttpHeader`

## Testing
- Fixes the SIGSEGV panic reported in production logs
