### PR TITLE
deps: Bump V8 13.8.258.26 -> 14.6.202.10 to fix Wasm VM cloning crash

### DIFF
--- a/bazel/external/fp16.BUILD
+++ b/bazel/external/fp16.BUILD
@@ -10,6 +10,7 @@ cc_library(
         "include/fp16.h",
         "include/fp16/bitcasts.h",
         "include/fp16/fp16.h",
+        "include/fp16/macros.h",
     ],
     includes = ["include/"],
 )

--- a/bazel/external/simdutf.BUILD
+++ b/bazel/external/simdutf.BUILD
@@ -7,5 +7,10 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "simdutf",
     srcs = ["simdutf.cpp"],
-    hdrs = ["simdutf.h"],
+    hdrs = [
+        "simdutf.h",
+        # TODO(jwendell): Remove once LLVM toolchain is bumped to a version
+        # whose libc++ provides std::atomic_ref (LLVM 19+).
+        "atomic_ref_polyfill.h",
+    ],
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -769,6 +769,8 @@ def _v8():
         name = "v8",
         patches = [
             "@envoy//bazel:v8.patch",
+            "@envoy//bazel:v8_atomic_ref.patch",
+            "@envoy//bazel:v8_novtune.patch",
             "@envoy//bazel:v8_ppc64le.patch",
         ],
         patch_args = ["-p1"],
@@ -777,6 +779,12 @@ def _v8():
             "find ./src ./include -type f -exec sed -i.bak -e 's!#include \"third_party/fp16/src/include/fp16.h\"!#include \"fp16.h\"!' {} \\;",
             "find ./src ./include -type f -exec sed -i.bak -e 's!#include \"third_party/dragonbox/src/include/dragonbox/dragonbox.h\"!#include \"dragonbox/dragonbox.h\"!' {} \\;",
             "find ./src ./include -type f -exec sed -i.bak -e 's!#include \"third_party/fast_float/src/include/fast_float/!#include \"fast_float/!' {} \\;",
+            # TODO(jwendell): Remove the atomic_ref polyfill injection once the LLVM toolchain is
+            # bumped to a version whose libc++ provides std::atomic_ref (LLVM 19+).
+            "grep -rl 'std::atomic_ref' src/ include/ --include='*.h' --include='*.cc' | grep -v atomic_ref_polyfill | xargs -r sed -i '1s!^!#include \"src/base/atomic_ref_polyfill.h\"\\n!'",
+            # TODO(jwendell): Remove consteval->constexpr workaround once the LLVM toolchain is
+            # bumped. Clang 18 has bugs with consteval in template contexts (fixed in clang 19+).
+            "find ./src -type f \\( -name '*.h' -o -name '*.cc' \\) -exec sed -i 's/consteval/constexpr/g' {} \\;",
         ],
         repo_mapping = {
             "@abseil-cpp": "@com_google_absl",
@@ -820,6 +828,40 @@ def _simdutf():
     external_http_archive(
         name = "simdutf",
         build_file = "@envoy//bazel/external:simdutf.BUILD",
+        patch_cmds = [
+            # TODO(jwendell): Remove this polyfill once the LLVM toolchain is bumped to a
+            # version whose libc++ provides std::atomic_ref (LLVM 19+).
+            # LLVM 18's libc++ lacks std::atomic_ref; without it SIMDUTF_ATOMIC_REF is 0
+            # and the atomic_base64/atomic_binary functions are excluded from compilation.
+            """cat > atomic_ref_polyfill.h << 'EOF'
+#ifndef ATOMIC_REF_POLYFILL_H_
+#define ATOMIC_REF_POLYFILL_H_
+#include <atomic>
+#include <type_traits>
+#if !defined(__cpp_lib_atomic_ref)
+#define __cpp_lib_atomic_ref 201806L
+namespace std {
+template <typename T> struct atomic_ref {
+  static_assert(std::is_trivially_copyable_v<T>);
+  static constexpr std::size_t required_alignment = alignof(T);
+  explicit atomic_ref(T& obj) : ptr_(&obj) {}
+  atomic_ref(const atomic_ref&) = default;
+  T load(std::memory_order order = std::memory_order_seq_cst) const noexcept {
+    return reinterpret_cast<const std::atomic<T>*>(ptr_)->load(order);
+  }
+  void store(T desired, std::memory_order order = std::memory_order_seq_cst) const noexcept {
+    reinterpret_cast<std::atomic<T>*>(ptr_)->store(desired, order);
+  }
+private:
+  T* ptr_;
+};
+template <typename T> atomic_ref(T&) -> atomic_ref<T>;
+}  // namespace std
+#endif
+#endif
+EOF""",
+            "sed -i '1s!^!#include \"atomic_ref_polyfill.h\"\\n!' simdutf.cpp",
+        ],
     )
 
 def _intel_ittapi():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1194,10 +1194,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_url = "https://v8.dev",
         # NOTE: Update together with proxy_wasm_cpp_host, highway, fast_float, dragonbox, simdutf, and fp16.
         # Patch contains workaround for https://github.com/bazelbuild/rules_python/issues/1221
-        version = "13.8.258.26",
+        version = "14.6.202.10",
         # Follow this guide to pick next stable release: https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
         strip_prefix = "v8-{version}",
-        sha256 = "4ffc27074d3f79e8e6401e390443dcf02755349002be4a1b01e72a3cd9457d15",
+        sha256 = "09c3d9f796a671fb9630c7190032f00171ce99effd7c80c7aaeba148a7bcbc1b",
         urls = ["https://github.com/v8/v8/archive/refs/tags/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.v8"],
@@ -1252,9 +1252,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Header-only library for conversion to/from half-precision floating point formats.",
         project_url = "https://github.com/Maratyszcza/FP16",
         # NOTE: Update together with v8 and proxy_wasm_cpp_host.
-        version = "0a92994d729ff76a58f692d3028ca1b64b145d91",
+        version = "3d2de1816307bac63c16a297e8c4dc501b4076df",
         strip_prefix = "FP16-{version}",
-        sha256 = "e66e65515fa09927b348d3d584c68be4215cfe664100d01c9dbc7655a5716d70",
+        sha256 = "e2da4f41bae8869f8dee56f4c104e699e7de3a483b5e451fda8e76fbcc66c59a",
         urls = ["https://github.com/Maratyszcza/FP16/archive/{version}.zip"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.v8"],
@@ -1266,8 +1266,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Unicode routines (UTF8, UTF16, UTF32) and Base64: billions of characters per second using SSE2, AVX2, NEON, AVX-512, RISC-V Vector Extension, LoongArch64, POWER. Part of Node.js, WebKit/Safari, Ladybird, Chromium, Cloudflare Workers and Bun.",
         project_url = "https://github.com/simdutf/simdutf",
         # NOTE: Update together with v8 and proxy_wasm_cpp_host.
-        version = "7.3.4",
-        sha256 = "a8d2b481a2089280b84df7dc234223b658056b5bbd40bd4d476902d25d353a1f",
+        version = "8.1.0",
+        sha256 = "c3565a8567b21d0096d0366654db473597ea6e5408e464198dce0897be71e4d0",
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.wasm.runtime.v8"],

--- a/bazel/v8.patch
+++ b/bazel/v8.patch
@@ -1,20 +1,17 @@
-From bc2a85e39fd55879b9baed51429c08b27d5514c8 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Wed, 16 Jul 2025 16:55:02 -0400
-Subject: [PATCH 1/8] Disable pointer compression
-
-Pointer compression limits the maximum number of WasmVMs.
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- BUILD.bazel | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 3f5a87d054e..0a693b7ee10 100644
+index 85f31b7a..eeba8efa 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -292,7 +292,7 @@ v8_int(
+@@ -6,7 +6,7 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
+ load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+ load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+-load("@v8_python_deps//:requirements.bzl", "requirement")
++load("@base_pip3//:requirements.bzl", "requirement")
+ load(
+     "@v8//:bazel/defs.bzl",
+     "v8_binary",
+@@ -303,7 +303,7 @@ v8_int(
  # If no explicit value for v8_enable_pointer_compression, we set it to 'none'.
  v8_string(
      name = "v8_enable_pointer_compression",
@@ -23,111 +20,76 @@ index 3f5a87d054e..0a693b7ee10 100644
  )
  
  # Default setting for v8_enable_pointer_compression.
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From e9fb84e11334342ee8fcb50d7322412ab35e2ad0 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Tue, 22 Jul 2025 10:53:33 -0400
-Subject: [PATCH 2/8] Use already imported python dependencies
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- BUILD.bazel                                      | 2 +-
- third_party/inspector_protocol/code_generator.py | 2 ++
- 2 files changed, 3 insertions(+), 1 deletion(-)
-
-diff --git a/BUILD.bazel b/BUILD.bazel
-index 0a693b7ee10..522f00555e0 100644
---- a/BUILD.bazel
-+++ b/BUILD.bazel
-@@ -4,7 +4,7 @@
- 
- load("@bazel_skylib//lib:selects.bzl", "selects")
- load("@rules_python//python:defs.bzl", "py_binary", "py_test")
--load("@v8_python_deps//:requirements.bzl", "requirement")
-+load("@base_pip3//:requirements.bzl", "requirement")
- load(
-     "@v8//:bazel/defs.bzl",
-     "v8_binary",
-diff --git a/third_party/inspector_protocol/code_generator.py b/third_party/inspector_protocol/code_generator.py
-index b1bedb58951..e85fe664618 100755
---- a/third_party/inspector_protocol/code_generator.py
-+++ b/third_party/inspector_protocol/code_generator.py
-@@ -16,6 +16,8 @@ try:
- except ImportError:
-   import simplejson as json
- 
-+sys.path += [os.path.dirname(__file__)]
-+
- import pdl
- 
- try:
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From 251ef6027d97bade5e5d8eb5b173baa849c163b8 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Wed, 16 Jul 2025 20:29:10 -0400
-Subject: [PATCH 3/8] Add build flags to make V8 compile with GCC
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- bazel/defs.bzl | 3 +++
- 1 file changed, 3 insertions(+)
-
+@@ -4607,10 +4607,10 @@ v8_library(
+         ":noicu/generated_torque_definitions",
+     ],
+     deps = [
+-        ":lib_dragonbox",
+-        "//third_party/fast_float/src:fast_float",
+-        ":lib_fp16",
+-        ":simdutf",
++        "@dragonbox//:dragonbox",
++        "@fast_float//:fast_float",
++        "@fp16//:FP16",
++        "@simdutf//:simdutf",
+         ":v8_libbase",
+         "@abseil-cpp//absl/container:btree",
+         "@abseil-cpp//absl/container:flat_hash_map",
 diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 0539ea176ac..92c7aeb904f 100644
+index 9648e4a5..75102917 100644
 --- a/bazel/defs.bzl
 +++ b/bazel/defs.bzl
-@@ -106,7 +106,7 @@ def _default_args():
-             "@v8//bazel/config:is_posix": [
+@@ -98,7 +98,7 @@ def _default_args():
+ def _default_args():
+     return struct(
+-        deps = [":define_flags", "@libcxx//:libc++"],
++        deps = [":define_flags"],
+         defines = select({
+             "@v8//bazel/config:is_windows": [
+                 "UNICODE",
+@@ -112,8 +112,7 @@ def _default_args():
                  "-fPIC",
                  "-fno-strict-aliasing",
+-                "-fconstexpr-steps=2000000",
 -                "-Werror",
 +                "-Wno-error", # Envoy build should not fail for warnings in dependencies
                  "-Wextra",
                  "-Wno-unneeded-internal-declaration",
                  "-Wno-unknown-warning-option", # b/330781959
-@@ -117,6 +117,9 @@ def _default_args():
+@@ -123,6 +122,9 @@ def _default_args():
                  "-Wno-implicit-int-float-conversion",
                  "-Wno-deprecated-copy",
                  "-Wno-non-virtual-dtor",
 +                "-Wno-invalid-offsetof",
 +                "-Wno-dangling-pointer",
 +                "-Wno-dangling-reference",
+                 "-Wno-unnecessary-virtual-specifier",
                  "-isystem .",
              ],
-             "//conditions:default": [],
-@@ -141,6 +144,7 @@ def _default_args():
+@@ -133,6 +135,8 @@ def _default_args():
+             "@v8//bazel/config:is_clang": [
+                 "-Wno-invalid-offsetof",
++                # -fconstexpr-steps is clang-only; moved here from is_posix block.
++                "-fconstexpr-steps=2000000",
+                 "-Wno-deprecated-this-capture",
+                 "-Wno-deprecated-declarations",
+                 "-std=c++20",
+@@ -148,6 +152,9 @@ def _default_args():
                  "-Wno-return-type",
                  "-Wno-stringop-overflow",
                  "-Wno-deprecated-this-capture",
++                "-Wno-error", # Envoy build should not fail for warnings in dependencies
++                "-Wno-unused-variable",
 +                "-flax-vector-conversions", # for GCC builds on ARM
                  # Use GNU dialect, because GCC doesn't allow using
                  # ##__VA_ARGS__ when in standards-conforming mode.
                  "-std=gnu++2a",
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From e85e6b017a4843f660bf5331b389a57945a2c21d Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Tue, 22 Jul 2025 10:55:14 -0400
-Subject: [PATCH 4/8] Add support for --define=no_debug_info=1
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- bazel/defs.bzl | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 92c7aeb904f..937157ccb06 100644
---- a/bazel/defs.bzl
-+++ b/bazel/defs.bzl
-@@ -184,6 +184,11 @@ def _default_args():
+@@ -184,10 +192,27 @@ def _default_args():
+                 "Advapi32.lib",
+             ],
+             "@v8//bazel/config:is_macos": ["-pthread"],
+-            "//conditions:default": ["-Wl,--no-as-needed -ldl -latomic -pthread"],
++            "//conditions:default": ["-Wl,--no-as-needed -ldl -pthread"],
          }) + select({
              ":should_add_rdynamic": ["-rdynamic"],
              "//conditions:default": [],
@@ -136,33 +98,6 @@ index 92c7aeb904f..937157ccb06 100644
 +                "-g0",
 +            ],
 +            "//conditions:default": [],
-         }),
-     )
- 
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From b1d40bf065bb46a47cfe2eaf5d3477934f5f8c29 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Tue, 22 Jul 2025 10:55:51 -0400
-Subject: [PATCH 5/8] Allow compiling v8 on macOS 10.15 to 13.0. TODO(dio):
- Will remove this patch when
- https://bugs.chromium.org/p/v8/issues/detail?id=13428 is fixed.
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- bazel/defs.bzl | 12 ++++++++++++
- 1 file changed, 12 insertions(+)
-
-diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 937157ccb06..39663c97df4 100644
---- a/bazel/defs.bzl
-+++ b/bazel/defs.bzl
-@@ -189,6 +189,18 @@ def _default_args():
-                 "-g0",
-             ],
-             "//conditions:default": [],
 +        }) + select({
 +            "@v8//bazel/config:is_macos": [
 +                # The clang available on macOS catalina has a warning that isn't clean on v8 code.
@@ -178,25 +113,37 @@ index 937157ccb06..39663c97df4 100644
          }),
      )
  
--- 
-2.50.0.727.gbf7dc18ff4-goog
+diff --git a/src/common/globals.h b/src/common/globals.h
+--- a/src/common/globals.h
++++ b/src/common/globals.h
+@@ -578,7 +578,7 @@ static const char* kPointerTableAddressSpaceName = "v8-pointer-table";
+ // virtual memory ranges (PR_SET_VMA_ANON_NAME on Linux).
+ // TODO(saelo): It might be nicer to have one name per table type, e.g.
+ // v8-external-pointer-table, v8-trusted-pointer-table, etc.
+-static const char* kPointerTableAddressSpaceName = "v8-pointer-table";
++[[maybe_unused]] static const char* kPointerTableAddressSpaceName = "v8-pointer-table";
 
+ //
+ // JavaScript Dispatch Table
+diff --git a/src/compiler/turboshaft/wasm-shuffle-reducer.cc b/src/compiler/turboshaft/wasm-shuffle-reducer.cc
+--- a/src/compiler/turboshaft/wasm-shuffle-reducer.cc
++++ b/src/compiler/turboshaft/wasm-shuffle-reducer.cc
+@@ -461,7 +461,9 @@ void WasmShuffleAnalyzer::ProcessI8x16Shuffle(const OpIndex node) {
 
-From 9ed4744c3aecf18f0cc546ea7f4ba7d8cca1f0e7 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Wed, 16 Jul 2025 16:56:52 -0400
-Subject: [PATCH 6/8] Don't expose Wasm C API (only Wasm C++ API).
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- src/wasm/c-api.cc | 4 ++++
- 1 file changed, 4 insertions(+)
-
+   if (!DemandedByteLanes(&shuffle)) {
+     // Full width shuffles.
+-    wasm::SimdShuffle::ShuffleArray shuffle_bytes;
++    // TODO(jwendell): Remove <> workaround once LLVM toolchain is bumped (clang 18
++    // doesn't support default template args on alias templates without <>).
++    wasm::SimdShuffle::ShuffleArray<> shuffle_bytes;
+     std::copy_n(shuffle.shuffle, kSimd128Size, shuffle_bytes.begin());
+     auto canonical = wasm::SimdShuffle::TryMatchCanonical(shuffle_bytes);
+     switch (canonical) {
 diff --git a/src/wasm/c-api.cc b/src/wasm/c-api.cc
-index 05e4029f183..d705be96a16 100644
+index 78e62abb..d7edf951 100644
 --- a/src/wasm/c-api.cc
 +++ b/src/wasm/c-api.cc
-@@ -2472,6 +2472,8 @@ WASM_EXPORT auto Instance::exports() const -> ownvec<Extern> {
+@@ -2482,6 +2482,8 @@ WASM_EXPORT auto Instance::exports() const -> ownvec<Extern> {
  
  }  // namespace wasm
  
@@ -205,188 +152,22 @@ index 05e4029f183..d705be96a16 100644
  // BEGIN FILE wasm-c.cc
  
  extern "C" {
-@@ -3518,3 +3520,5 @@ wasm_instance_t* wasm_frame_instance(const wasm_frame_t* frame) {
+@@ -3528,3 +3530,5 @@ wasm_instance_t* wasm_frame_instance(const wasm_frame_t* frame) {
  #undef WASM_DEFINE_SHARABLE_REF
  
  }  // extern "C"
 +
 +#endif
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From 2d4bb2b8bff5a45fd0452912b936e2f9f463b001 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Wed, 16 Jul 2025 20:04:05 -0400
-Subject: [PATCH 7/8] Stub out vendored dependencies for bazel-sourced versions
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- BUILD.bazel | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
-
-diff --git a/BUILD.bazel b/BUILD.bazel
-index 522f00555e0..f775a934c17 100644
---- a/BUILD.bazel
-+++ b/BUILD.bazel
-@@ -4437,10 +4437,10 @@ v8_library(
-         ":noicu/generated_torque_definitions",
-     ],
-     deps = [
--        ":lib_dragonbox",
--        "//third_party/fast_float/src:fast_float",
--        ":lib_fp16",
--        ":simdutf",
-+        "@dragonbox//:dragonbox",
-+        "@fast_float//:fast_float",
-+        "@fp16//:FP16",
-+        "@simdutf//:simdutf",
-         ":v8_libbase",
-         "@abseil-cpp//absl/container:btree",
-         "@abseil-cpp//absl/container:flat_hash_map",
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
-
-From 5c0418f72733f62242d0c83eaacdb5bfd91c1e67 Mon Sep 17 00:00:00 2001
-From: Matt Leon <mattleon@google.com>
-Date: Fri, 18 Jul 2025 17:28:42 -0400
-Subject: [PATCH 8/8] Hack out atomic simd support in V8.
-
-Atomic simdutf requires __cpp_lib_atomic_ref >= 201806, which is only
-supported in clang libc++ 19+. The version of LLVM used in Envoy as of
-2025-07-18 is libc++ 18, so this is not supported.
-
-The simdutf documentation indicates this atomic form is not tested and
-is not recommended for use:
-https://github.com/simdutf/simdutf/blob/5d1b6248f29a8ed0eb90f79be268be41730e39f8/include/simdutf/implementation.h#L3066-L3068
-
-In addition, this is in the implementation of a JS array buffer. Since
-proxy-wasm-cpp-host does not make use of JS array buffers or shared
-memory between web workers, we're stubbing it out.
-
-Mostly reverts
-https://github.com/v8/v8/commit/6d6c1e680c7b8ea5f62a76e9c3d88d3fb0a88df0.
-
-Signed-off-by: Matt Leon <mattleon@google.com>
----
- bazel/defs.bzl                       |  2 +-
- src/builtins/builtins-typed-array.cc |  8 ++++++++
- src/objects/simd.cc                  | 10 ++++++++++
- 3 files changed, 19 insertions(+), 1 deletion(-)
-
-diff --git a/bazel/defs.bzl b/bazel/defs.bzl
-index 39663c97df4..14b90ec6905 100644
---- a/bazel/defs.bzl
-+++ b/bazel/defs.bzl
-@@ -180,7 +180,7 @@ def _default_args():
-                 "Advapi32.lib",
-             ],
-             "@v8//bazel/config:is_macos": ["-pthread"],
--            "//conditions:default": ["-Wl,--no-as-needed -ldl -latomic -pthread"],
-+            "//conditions:default": ["-Wl,--no-as-needed -ldl -pthread"],
-         }) + select({
-             ":should_add_rdynamic": ["-rdynamic"],
-             "//conditions:default": [],
-diff --git a/src/builtins/builtins-typed-array.cc b/src/builtins/builtins-typed-array.cc
-index 918cb873481..bc933e8dc1d 100644
---- a/src/builtins/builtins-typed-array.cc
-+++ b/src/builtins/builtins-typed-array.cc
-@@ -520,17 +520,21 @@ simdutf::result ArrayBufferSetFromBase64(
-     DirectHandle<JSTypedArray> typed_array, size_t& output_length) {
-   output_length = array_length;
-   simdutf::result simd_result;
-+#ifdef WANT_ATOMIC_REF
-   if (typed_array->buffer()->is_shared()) {
-     simd_result = simdutf::atomic_base64_to_binary_safe(
-         reinterpret_cast<const T>(input_vector), input_length,
-         reinterpret_cast<char*>(typed_array->DataPtr()), output_length,
-         alphabet, last_chunk_handling, /*decode_up_to_bad_char*/ true);
-   } else {
-+#endif
-     simd_result = simdutf::base64_to_binary_safe(
-         reinterpret_cast<const T>(input_vector), input_length,
-         reinterpret_cast<char*>(typed_array->DataPtr()), output_length,
-         alphabet, last_chunk_handling, /*decode_up_to_bad_char*/ true);
-+#ifdef WANT_ATOMIC_REF
-   }
-+#endif
+diff --git a/third_party/inspector_protocol/code_generator.py b/third_party/inspector_protocol/code_generator.py
+index 49952dda..268af813 100755
+--- a/third_party/inspector_protocol/code_generator.py
++++ b/third_party/inspector_protocol/code_generator.py
+@@ -16,6 +16,8 @@ try:
+ except ImportError:
+   import simplejson as json
  
-   return simd_result;
- }
-@@ -833,15 +837,19 @@ BUILTIN(Uint8ArrayPrototypeToBase64) {
-     // 11. Return CodePointsToString(outAscii).
++sys.path += [os.path.dirname(__file__)]
++
+ import pdl
  
-     size_t simd_result_size;
-+#ifdef WANT_ATOMIC_REF
-     if (uint8array->buffer()->is_shared()) {
-       simd_result_size = simdutf::atomic_binary_to_base64(
-           std::bit_cast<const char*>(uint8array->DataPtr()), length,
-           reinterpret_cast<char*>(output->GetChars(no_gc)), alphabet);
-     } else {
-+#endif
-       simd_result_size = simdutf::binary_to_base64(
-           std::bit_cast<const char*>(uint8array->DataPtr()), length,
-           reinterpret_cast<char*>(output->GetChars(no_gc)), alphabet);
-+#ifdef WANT_ATOMIC_REF
-     }
-+#endif
-     DCHECK_EQ(simd_result_size, output_length);
-     USE(simd_result_size);
-   }
-diff --git a/src/objects/simd.cc b/src/objects/simd.cc
-index 0ef570ceb7d..9217fa76072 100644
---- a/src/objects/simd.cc
-+++ b/src/objects/simd.cc
-@@ -477,6 +477,7 @@ void Uint8ArrayToHexSlow(const char* bytes, size_t length,
-   }
- }
- 
-+#ifdef WANT_ATOMIC_REF
- void AtomicUint8ArrayToHexSlow(const char* bytes, size_t length,
-                                DirectHandle<SeqOneByteString> string_output) {
-   int index = 0;
-@@ -492,6 +493,7 @@ void AtomicUint8ArrayToHexSlow(const char* bytes, size_t length,
-     index += 2;
-   }
- }
-+#endif
- 
- inline uint16_t ByteToHex(uint8_t byte) {
-   const uint16_t correction = (('a' - '0' - 10) << 8) + ('a' - '0' - 10);
-@@ -645,11 +647,15 @@ Tagged<Object> Uint8ArrayToHex(const char* bytes, size_t length, bool is_shared,
-   }
- #endif
- 
-+#ifdef WANT_ATOMIC_REF
-   if (is_shared) {
-     AtomicUint8ArrayToHexSlow(bytes, length, string_output);
-   } else {
-+#endif
-     Uint8ArrayToHexSlow(bytes, length, string_output);
-+#ifdef WANT_ATOMIC_REF
-   }
-+#endif
-   return *string_output;
- }
- 
-@@ -1082,12 +1088,16 @@ bool ArrayBufferFromHex(const base::Vector<T>& input_vector, bool is_shared,
-   for (uint32_t i = 0; i < output_length * 2; i += 2) {
-     result = HandleRemainingHexValues(input_vector, i);
-     if (result.has_value()) {
-+#ifdef WANT_ATOMIC_REF
-       if (is_shared) {
-         std::atomic_ref<uint8_t>(buffer[index++])
-             .store(result.value(), std::memory_order_relaxed);
-       } else {
-+#endif
-         buffer[index++] = result.value();
-+#ifdef WANT_ATOMIC_REF
-       }
-+#endif
-     } else {
-       return false;
-     }
--- 
-2.50.0.727.gbf7dc18ff4-goog
-
+ try:

--- a/bazel/v8_atomic_ref.patch
+++ b/bazel/v8_atomic_ref.patch
@@ -1,0 +1,85 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index eeba8efa..eeba8efb 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -817,6 +817,7 @@ filegroup(
+         "src/base/address-region.h",
+         "src/base/algorithm.h",
+         "src/base/atomic-utils.h",
++        "src/base/atomic_ref_polyfill.h",
+         "src/base/atomicops.h",
+         "src/base/base-export.h",
+         "src/base/bit-field.h",
+diff --git a/src/base/atomic_ref_polyfill.h b/src/base/atomic_ref_polyfill.h
+new file mode 100644
+--- /dev/null
++++ b/src/base/atomic_ref_polyfill.h
+@@ -0,0 +1,68 @@
++// Polyfill for std::atomic_ref (C++20 P0019R8) when libc++ doesn't provide it.
++// LLVM 18's libc++ does not ship std::atomic_ref; V8 14.6 uses it pervasively.
++// TODO(jwendell): Remove this polyfill once the LLVM toolchain is bumped to a
++// version whose libc++ provides std::atomic_ref (LLVM 19+).
++#ifndef V8_BASE_ATOMIC_REF_POLYFILL_H_
++#define V8_BASE_ATOMIC_REF_POLYFILL_H_
++
++#include <atomic>
++#include <type_traits>
++
++#if !defined(__cpp_lib_atomic_ref)
++#define __cpp_lib_atomic_ref 201806L
++namespace std {
++template <typename T>
++struct atomic_ref {
++  static_assert(std::is_trivially_copyable_v<T>);
++  static constexpr std::size_t required_alignment = alignof(T);
++  explicit atomic_ref(T& obj) : ptr_(&obj) {}
++  atomic_ref(const atomic_ref&) = default;
++  T load(std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<const std::atomic<T>*>(ptr_)->load(order);
++  }
++  void store(T desired, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    reinterpret_cast<std::atomic<T>*>(ptr_)->store(desired, order);
++  }
++  T exchange(T desired, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->exchange(desired, order);
++  }
++  bool compare_exchange_strong(T& expected, T desired,
++                               std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->compare_exchange_strong(expected, desired, order);
++  }
++  bool compare_exchange_strong(T& expected, T desired,
++                               std::memory_order success, std::memory_order failure) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->compare_exchange_strong(expected, desired, success, failure);
++  }
++  bool compare_exchange_weak(T& expected, T desired,
++                             std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->compare_exchange_weak(expected, desired, order);
++  }
++  bool compare_exchange_weak(T& expected, T desired,
++                             std::memory_order success, std::memory_order failure) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->compare_exchange_weak(expected, desired, success, failure);
++  }
++  T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->fetch_add(arg, order);
++  }
++  T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->fetch_sub(arg, order);
++  }
++  T fetch_and(T arg, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->fetch_and(arg, order);
++  }
++  T fetch_or(T arg, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->fetch_or(arg, order);
++  }
++  T fetch_xor(T arg, std::memory_order order = std::memory_order_seq_cst) const noexcept {
++    return reinterpret_cast<std::atomic<T>*>(ptr_)->fetch_xor(arg, order);
++  }
++private:
++  T* ptr_;
++};
++template <typename T>
++atomic_ref(T&) -> atomic_ref<T>;
++}  // namespace std
++#endif  // !defined(__cpp_lib_atomic_ref)
++
++#endif  // V8_BASE_ATOMIC_REF_POLYFILL_H_

--- a/bazel/v8_novtune.patch
+++ b/bazel/v8_novtune.patch
@@ -1,0 +1,18 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 3f5a87d054e..740b1f1773b 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -4477,12 +4477,7 @@ v8_library(
+     copts = ["-Wno-implicit-fallthrough"],
+     strip_include_prefix = "third_party",
+     visibility = ["//visibility:public"],
+-    deps = [":noicu/v8"] + select({
+-        ":is_v8_enable_vtunejit": [
+-            ":v8_vtune",
+-        ],
+-        "//conditions:default": [],
+-    }),
++    deps = [":noicu/v8"],
+ )
+ 
+ alias(


### PR DESCRIPTION
Cherry-pick of envoyproxy/envoy#43928

## Problem
V8 13.8 uses a per-`IsolateGroup` `JSDispatchTable`, which creates a race condition when multiple Isolates are created concurrently (e.g., during Wasm VM cloning). This can cause crashes.

## Fix
Bump V8 to 14.6.202.10 which converts `JSDispatchTable` from per-`IsolateGroup` to per-`Isolate` (V8 commit 4d1e2794e), eliminating the race condition.

## Dependency Updates
- **simdutf** 7.3.4 -> 8.1.0 (V8 14.6 uses atomic simdutf functions)
- **fp16** updated to revision 3d2de1816 (matches V8 14.6 bundled version)

## LLVM 18 Compatibility Workarounds
All marked with `TODO(jwendell)` for removal once LLVM is bumped to 19+:
- `std::atomic_ref` polyfill header injected into V8 and simdutf
- `consteval` -> `constexpr` downgrade for clang 18 template bugs
- `ShuffleArray<>` template argument deduction fix

## Conflict Resolution
- `bazel/deps.yaml`: Deleted in envoy-1.36 (not present) — resolved by removing
- `bazel/repositories.bzl`: Added new patch entries while keeping `v8_ppc64le.patch` from envoy-1.36

## Files Changed
- `bazel/repository_locations.bzl` — V8, simdutf, fp16 version bumps
- `bazel/repositories.bzl` — New patches + patch_cmds for V8 14.6
- `bazel/v8.patch` — Updated for V8 14.6
- `bazel/v8_atomic_ref.patch` — New: atomic_ref polyfill injection
- `bazel/v8_novtune.patch` — New: disable VTune JIT profiling
- `bazel/external/simdutf.BUILD` — Add atomic_ref_polyfill.h header
- `bazel/external/fp16.BUILD` — Add macros.h header

Upstream PR: https://github.com/envoyproxy/envoy/pull/43928