### PR TITLE
fix(custom_response): avoid overriding decoder buffer limit when max_request_bytes is unset

### DIFF
--- a/source/extensions/filters/http/custom_response/custom_response_filter.cc
+++ b/source/extensions/filters/http/custom_response/custom_response_filter.cc
@@ -74,7 +74,9 @@ Http::FilterDataStatus CustomResponseFilter::decodeData(Buffer::Instance&, bool)
       decoder_callbacks_->streamInfo().setDynamicMetadata("envoy.filters.http.custom_response",
                                                           metadata);
       decoder_callbacks_->setNeedBuffering(true);
-      decoder_callbacks_->setDecoderBufferLimit(config->maxRequestBytes());
+      if (config->maxRequestBytes() > 0) {
+        decoder_callbacks_->setDecoderBufferLimit(config->maxRequestBytes());
+      }
     }
     has_checked_ = true;
   }


### PR DESCRIPTION
## Summary

- Fixes a regression where `CustomResponseFilter::decodeData` unconditionally calls `setDecoderBufferLimit(config->maxRequestBytes())`, clobbering any previously-set decoder buffer limit with `0` when the user does not configure `custom_response.with_request_body`.
- Restores the intent of the original `withRequestBody()` guard (equivalent to `max_request_bytes_ > 0`) by only invoking `setDecoderBufferLimit` when `maxRequestBytes() > 0`.

## Background

Reported in higress-group/higress#3782: after upgrading to Higress 2.2.x (envoy-1.36 branch), the wasm plugin's `SetRequestBodyBufferLimit(20480)` no longer takes effect on the first request. The log shows:

```
SetRequestBodyBufferLimit: 20480
setting buffer limit to 20480
onBelowReadBufferLowWatermark
setting buffer limit to 0    <-- overridden
setting buffer limit to 0
...
```

In Higress 2.1.9 (envoy-1.27), the same plugin works correctly because `CustomResponseFilter` only had a `decodeHeaders` override guarded by `config->withRequestBody()`.

The 1.36 branch added a HIGRESS-specific `decodeData` override (commit `6a067cced4`, "envoy ai 相关功能内存优化") to defer the `setDecoderBufferLimit` call until body data arrives. Commit `eb06d49fc8` ("remove check for max_request_bytes_") later removed the `config->withRequestBody()` check from both `decodeHeaders` and `decodeData`, but only removed the `setDecoderBufferLimit`/`setNeedBuffering` calls from `decodeHeaders` — leaving `decodeData` to call `setDecoderBufferLimit(0)` whenever `with_request_body` is unset.

## Fix

```cpp
decoder_callbacks_->setNeedBuffering(true);
if (config->maxRequestBytes() > 0) {
  decoder_callbacks_->setDecoderBufferLimit(config->maxRequestBytes());
}
```

`setNeedBuffering(true)` is preserved because router.cc:992 reads `callbacks_->needBuffering()` to decide whether to back up the original request body for AI fallback.

## Test plan

- [ ] Verify the issue from higress-group/higress#3782 is fixed: with no `custom_response.with_request_body` configured, a wasm plugin calling `SetRequestBodyBufferLimit(20480)` retains the 20480 limit on the first request.
- [ ] Verify existing custom_response AI fallback flow still works when `with_request_body.max_request_bytes` IS configured (the original buffered request body is captured for fallback).
- [ ] Existing custom_response unit tests still pass.