### PR TITLE
fix(wasm): guard proactive rebuilds by active generation

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -17,6 +17,7 @@
 #include "envoy/network/filter.h"
 #include "envoy/stats/sink.h"
 #include "envoy/thread_local/thread_local.h"
+
 #if defined(HIGRESS)
 #include "envoy/redis/async_client.h"
 #endif
@@ -208,7 +209,27 @@ Context::Context(Wasm* wasm, uint32_t root_context_id, PluginHandleSharedPtr plu
   allow_on_headers_stop_iteration_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
       plugin()->wasmConfig().config(), allow_on_headers_stop_iteration,
       DefaultAllowOnHeadersStopIteration);
+#if defined(HIGRESS)
+  if (wasm != nullptr && plugin_handle_ != nullptr && plugin_handle_->wasmHandle() != nullptr &&
+      plugin_handle_->wasmHandle()->wasm() != nullptr) {
+    plugin_handle_->wasmHandle()->wasm()->incrementActiveStreamCount();
+    active_stream_count_recorded_ = true;
+  }
+#endif
 }
+
+#if defined(HIGRESS)
+void Context::releaseActiveStream() {
+  if (!active_stream_count_recorded_) {
+    return;
+  }
+  active_stream_count_recorded_ = false;
+  if (plugin_handle_ != nullptr && plugin_handle_->wasmHandle() != nullptr &&
+      plugin_handle_->wasmHandle()->wasm() != nullptr) {
+    plugin_handle_->wasmHandle()->wasm()->decrementActiveStreamCount();
+  }
+}
+#endif
 
 Wasm* Context::wasm() const { return static_cast<Wasm*>(wasm_); }
 Plugin* Context::plugin() const { return static_cast<Plugin*>(plugin_.get()); }
@@ -231,8 +252,14 @@ uint64_t Context::getMonotonicTimeNanoseconds() {
 
 void Context::onCloseTCP() {
   if (tcp_connection_closed_ || !in_vm_context_created_) {
+#if defined(HIGRESS)
+    releaseActiveStream();
+#endif
     return;
   }
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   tcp_connection_closed_ = true;
   onDone();
   onLog();
@@ -1689,6 +1716,9 @@ WasmResult Context::getMetric(uint32_t metric_id, uint64_t* result_uint64_ptr) {
 }
 
 Context::~Context() {
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   // Cancel any outstanding requests.
   for (auto& p : http_request_) {
     if (p.second.request_ != nullptr) {
@@ -1879,6 +1909,9 @@ void Context::log(const Formatter::HttpFormatterContext& log_context,
 }
 
 void Context::onDestroy() {
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   if (destroyed_ || !in_vm_context_created_) {
     return;
   }

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -319,6 +319,9 @@ protected:
 
   void addAfterVmCallAction(std::function<void()> f);
   void onCloseTCP();
+#if defined(HIGRESS)
+  void releaseActiveStream();
+#endif
 
   struct AsyncClientHandler : public Http::AsyncClient::Callbacks {
     // Http::AsyncClient::Callbacks
@@ -441,6 +444,9 @@ protected:
 
   const LocalInfo::LocalInfo* root_local_info_{nullptr}; // set only for root_context.
   PluginHandleSharedPtr plugin_handle_{nullptr};
+#if defined(HIGRESS)
+  bool active_stream_count_recorded_ = false;
+#endif
 
   uint32_t next_http_call_token_ = 1;
   uint32_t next_grpc_token_ = 1; // Odd tokens are for Calls even for Streams.

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <string>
+#include <vector>
 
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/extensions/wasm/v3/wasm.pb.h"
@@ -14,6 +16,7 @@
 #include "source/extensions/common/wasm/remote_async_datasource.h"
 #include "source/extensions/common/wasm/stats_handler.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
 
 using proxy_wasm::FailState;
@@ -90,6 +93,62 @@ WasmEvent failStateToWasmEvent(FailState state) {
 }
 
 const int MIN_RECOVER_INTERVAL_SECONDS = 1;
+
+struct RebuildGuardEntry {
+  MonotonicTime last_recover_time;
+  std::weak_ptr<WasmHandle> current_wasm_handle;
+  std::vector<std::weak_ptr<WasmHandle>> old_wasm_handles;
+
+  void pruneExpired(const WasmHandleSharedPtr& current_wasm_handle = nullptr) {
+    old_wasm_handles.erase(
+        std::remove_if(old_wasm_handles.begin(), old_wasm_handles.end(),
+                       [&current_wasm_handle](const std::weak_ptr<WasmHandle>& old_wasm_handle) {
+                         auto locked = old_wasm_handle.lock();
+                         return locked == nullptr || (current_wasm_handle != nullptr &&
+                                                      locked.get() == current_wasm_handle.get());
+                       }),
+        old_wasm_handles.end());
+  }
+
+  bool hasLiveOldGeneration(const WasmHandleSharedPtr& current_wasm_handle) {
+    pruneExpired(current_wasm_handle);
+    return !old_wasm_handles.empty();
+  }
+
+  void trackCurrentGeneration(const WasmHandleSharedPtr& wasm_handle) {
+    current_wasm_handle = wasm_handle;
+  }
+
+  void trackOldGeneration(const WasmHandleSharedPtr& old_wasm_handle) {
+    if (old_wasm_handle == nullptr) {
+      return;
+    }
+    pruneExpired();
+    old_wasm_handles.push_back(old_wasm_handle);
+  }
+
+  bool canRetire() {
+    pruneExpired();
+    return current_wasm_handle.expired() && old_wasm_handles.empty();
+  }
+};
+
+thread_local absl::flat_hash_map<std::string, RebuildGuardEntry> rebuild_guard_registry;
+
+void sweepRebuildGuardRegistry(const std::string& active_vm_key) {
+  for (auto it = rebuild_guard_registry.begin(); it != rebuild_guard_registry.end();) {
+    if (it->first == active_vm_key) {
+      ++it;
+      continue;
+    }
+    if (it->second.canRetire()) {
+      auto erase_it = it++;
+      rebuild_guard_registry.erase(erase_it);
+    } else {
+      ++it;
+    }
+  }
+}
 #endif
 
 } // namespace
@@ -218,26 +277,39 @@ bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery) {
     ENVOY_LOG(warn, "wasm has not been initialized");
     return false;
   }
-  auto& dispatcher = handle->wasmHandle()->wasm()->dispatcher();
+  auto current_wasm_handle = handle->wasmHandle();
+  auto current_wasm = current_wasm_handle->wasm();
+  const std::string vm_key(current_wasm->vm_key());
+  sweepRebuildGuardRegistry(vm_key);
+  auto& guard = rebuild_guard_registry[vm_key];
+  guard.trackCurrentGeneration(current_wasm_handle);
+  auto& dispatcher = current_wasm->dispatcher();
   auto now = dispatcher.timeSource().monotonicTime() + cache_time_offset_for_testing;
-  if (now - last_recover_time_ < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
-    ENVOY_LOG(info, "rebuild interval has not been reached");
+  if (now - guard.last_recover_time < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
+    ENVOY_LOG(info, "wasm vm rebuild skipped: recover interval has not been reached");
     return false;
   }
-  // Check if old handle is still alive (still being referenced by old requests)
-  // If it's still alive, we don't want to create another VM to prevent memory accumulation
-  // For fail recovery scenarios, skip this check to ensure recovery can proceed
-  if (!is_fail_recovery && !old_handle_.expired()) {
-    ENVOY_LOG(info, "old wasm vm handle is still in use, skipping rebuild to prevent VM accumulation");
-    return false;
+  if (!is_fail_recovery && guard.hasLiveOldGeneration(current_wasm_handle)) {
+    const auto active_stream_count = current_wasm->activeStreamCount();
+    if (active_stream_count > 0) {
+      ENVOY_LOG(info,
+                "wasm vm proactive rebuild skipped: old generation is still live and current "
+                "generation has {} active streams",
+                active_stream_count);
+      return false;
+    }
   }
   // Even if rebuild fails, it will be retried after the interval
-  last_recover_time_ = now;
+  guard.last_recover_time = now;
   std::shared_ptr<PluginHandleBase> new_handle;
-  if (handle->rebuild(new_handle)) {
-    // Store weak_ptr to current handle before replacing it
-    old_handle_ = handle;
-    handle = std::static_pointer_cast<PluginHandle>(new_handle);
+  if (handle->rebuild(new_handle) && new_handle != nullptr) {
+    auto new_plugin_handle = std::static_pointer_cast<PluginHandle>(new_handle);
+    auto new_wasm_handle = new_plugin_handle->wasmHandle();
+    if (new_wasm_handle != nullptr && new_wasm_handle.get() != current_wasm_handle.get()) {
+      guard.trackOldGeneration(current_wasm_handle);
+    }
+    guard.trackCurrentGeneration(new_wasm_handle);
+    handle = new_plugin_handle;
     // Increment appropriate metrics based on rebuild type
     if (is_fail_recovery) {
       handle->wasmHandle()->wasm()->lifecycleStats().recover_total_.inc();
@@ -248,6 +320,7 @@ bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery) {
     }
     return true;
   }
+  ENVOY_LOG(info, "wasm vm {} execution failed", is_fail_recovery ? "recover" : "rebuild");
   return false;
 }
 #endif
@@ -345,8 +418,16 @@ void clearCodeCacheForTesting() {
     delete code_cache;
     code_cache = nullptr;
   }
+  cache_time_offset_for_testing = {};
+#if defined(HIGRESS)
+  rebuild_guard_registry.clear();
+#endif
   getCreateStatsHandler().resetStatsForTesting();
 }
+
+#if defined(HIGRESS)
+size_t rebuildGuardRegistrySizeForTesting() { return rebuild_guard_registry.size(); }
+#endif
 
 // TODO: remove this post #4160: Switch default to SimulatedTimeSystem.
 void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d) {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -96,6 +96,16 @@ public:
 
 #if defined(HIGRESS)
   LifecycleStats& lifecycleStats() { return lifecycle_stats_handler_.stats(); }
+  void incrementActiveStreamCount() { ++active_stream_count_; }
+  void decrementActiveStreamCount() {
+    ASSERT(active_stream_count_ > 0);
+    if (active_stream_count_ == 0) {
+      ENVOY_LOG(error, "wasm active stream count underflow");
+      return;
+    }
+    --active_stream_count_;
+  }
+  uint64_t activeStreamCount() const { return active_stream_count_; }
 #endif
 
 protected:
@@ -120,6 +130,7 @@ protected:
   RuntimeStatsHandler runtime_stats_handler_;
   Event::TimerPtr runtime_stats_timer_;
   static constexpr std::chrono::milliseconds kRuntimeStatsInterval{1000};
+  uint64_t active_stream_count_ = 0;
 #endif
 
   // Lifecycle stats
@@ -182,10 +193,6 @@ public:
   PluginHandleSharedPtrThreadLocal() = default;
 
   bool rebuild(bool is_fail_recovery = false);
-
-private:
-  MonotonicTime last_recover_time_;
-  std::weak_ptr<PluginHandle> old_handle_;
 };
 #else
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject {
@@ -219,6 +226,9 @@ getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginS
 
 void clearCodeCacheForTesting();
 void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d);
+#if defined(HIGRESS)
+size_t rebuildGuardRegistrySizeForTesting();
+#endif
 WasmEvent toWasmEvent(const std::shared_ptr<WasmHandleBase>& wasm);
 
 class PluginConfig : Logger::Loggable<Logger::Id::wasm> {

--- a/test/extensions/filters/http/wasm/BUILD
+++ b/test/extensions/filters/http/wasm/BUILD
@@ -43,6 +43,7 @@ envoy_extension_cc_test(
         "skip_on_windows",
     ],
     deps = [
+        "//source/common/http:conn_manager_lib",
         "//source/common/http:message_lib",
         "//source/extensions/filters/http/wasm:wasm_filter_lib",
         "//test/extensions/common/wasm:wasm_runtime",

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "envoy/grpc/async_client.h"
 #include "envoy/redis/async_client.h"
 
@@ -35,7 +37,9 @@ namespace Wasm {
 
 using Envoy::Extensions::Common::Wasm::CreateContextFn;
 using Envoy::Extensions::Common::Wasm::Plugin;
+using Envoy::Extensions::Common::Wasm::PluginHandle;
 using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtr;
+using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtrThreadLocal;
 using Envoy::Extensions::Common::Wasm::Wasm;
 using Envoy::Extensions::Common::Wasm::WasmHandleSharedPtr;
 using proxy_wasm::ContextBase;
@@ -97,10 +101,55 @@ public:
   TestRoot& rootContext() { return *static_cast<TestRoot*>(root_context_); }
   TestFilter& filter() { return *static_cast<TestFilter*>(context_.get()); }
 
+#if defined(HIGRESS)
+  void advanceRebuildInterval() {
+    rebuild_time_offset_ += std::chrono::seconds(2);
+    Envoy::Extensions::Common::Wasm::setTimeOffsetForCodeCacheForTesting(rebuild_time_offset_);
+  }
+
+  bool rebuildThroughThreadLocal(PluginHandleSharedPtrThreadLocal& thread_local_handle,
+                                 bool is_fail_recovery = false) {
+    if (!is_fail_recovery && thread_local_handle.handle != nullptr &&
+        thread_local_handle.handle->wasmHandle() != nullptr &&
+        thread_local_handle.handle->wasmHandle()->wasm() != nullptr) {
+      thread_local_handle.handle->wasmHandle()->wasm()->setShouldRebuild(true);
+    }
+    const bool rebuilt = thread_local_handle.rebuild(is_fail_recovery);
+    if (rebuilt) {
+      plugin_handle_ = thread_local_handle.handle;
+      wasm_ = plugin_handle_->wasmHandle();
+      if (!is_fail_recovery && wasm_ != nullptr && wasm_->wasm() != nullptr) {
+        wasm_->wasm()->setShouldRebuild(false);
+      }
+    }
+    return rebuilt;
+  }
+
+  std::unique_ptr<TestFilter> makeStreamContext(const PluginHandleSharedPtr& plugin_handle) {
+    auto* wasm = plugin_handle != nullptr && plugin_handle->wasmHandle() != nullptr
+                     ? plugin_handle->wasmHandle()->wasm().get()
+                     : nullptr;
+    const uint32_t root_context_id = wasm != nullptr ? plugin_handle->rootContextId() : 0;
+    return std::make_unique<TestFilter>(wasm, root_context_id, plugin_handle);
+  }
+
+  void releaseWasmState() {
+    context_.reset();
+    plugin_handle_.reset();
+    wasm_.reset();
+    base_wasm_.reset();
+    plugin_.reset();
+    root_context_ = nullptr;
+  }
+#endif
+
 protected:
   NiceMock<Grpc::MockAsyncStream> async_stream_;
   Grpc::MockAsyncClientManager async_client_manager_;
   NiceMock<Tracing::MockSpan> mock_span_;
+#if defined(HIGRESS)
+  std::chrono::seconds rebuild_time_offset_{0};
+#endif
 };
 
 INSTANTIATE_TEST_SUITE_P(RuntimesAndLanguages, WasmHttpFilterTest,
@@ -2081,6 +2130,270 @@ TEST_P(WasmHttpFilterTest, GetVMMemorySize) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   filter().onDestroy();
 }
+
+TEST_P(WasmHttpFilterTest, ActiveStreamCounterTracksStreamContextLifetime) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  {
+    auto stream_context = makeStreamContext(plugin_handle_);
+    EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+    stream_context->onDestroy();
+    EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+  }
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  {
+    auto stream_context = makeStreamContext(plugin_handle_);
+    EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+  }
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildNoOldGenerationStillSucceeds) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& recover_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.recover_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, recover_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentActive) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+  PluginHandleSharedPtr current_generation_handle = thread_local_handle.handle;
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(current_generation_handle.get(), thread_local_handle.handle.get());
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildAllowsWhenOldGenerationLiveAndCurrentIdle) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(2U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(2U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, RebuildGuardRegistryRetiresStaleVmKeys) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  {
+    PluginHandleSharedPtrThreadLocal first_thread_local_handle(plugin_handle_);
+    advanceRebuildInterval();
+    ASSERT_TRUE(rebuildThroughThreadLocal(first_thread_local_handle));
+    EXPECT_EQ(1U, Envoy::Extensions::Common::Wasm::rebuildGuardRegistrySizeForTesting());
+  }
+  releaseWasmState();
+
+  setupTest("", "RebuildTestRegistryRetire");
+  PluginHandleSharedPtrThreadLocal second_thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(second_thread_local_handle));
+  EXPECT_EQ(1U, Envoy::Extensions::Common::Wasm::rebuildGuardRegistrySizeForTesting());
+}
+
+TEST_P(WasmHttpFilterTest, NewThreadLocalWrapperKeepsRebuildGuardState) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  PluginHandleSharedPtrThreadLocal new_wrapper(plugin_handle_);
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(new_wrapper));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, ActiveCounterIncludesDifferentPluginHandleOnSameGeneration) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto sibling_plugin_handle =
+      std::make_shared<PluginHandle>(plugin_handle_->wasmHandle(), plugin_);
+  auto sibling_stream_context = makeStreamContext(sibling_plugin_handle);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  sibling_stream_context->onDestroy();
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, FailRecoveryBypassesProactiveActiveGuard) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& recover_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.recover_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, recover_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle, true));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(1U, recover_total.value());
+
+  current_stream_context->onDestroy();
+}
+
 TEST_P(WasmHttpFilterTest, RecoverFromCrash) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {


### PR DESCRIPTION
## Summary

Related to higress-group/higress#3920.

This ports the Wasm rebuild guard optimization to the open-source Higress Envoy `envoy-1.36` branch.

- Track active stream count on the current Higress Wasm VM generation.
- Replace the per-wrapper `old_handle_` guard with a worker-local rebuild guard registry keyed by `vm_key`.
- Allow proactive rebuild when an old generation is still live but the current generation is idle.
- Keep the anti-accumulation guard when both an old generation is live and the current generation still has active streams.
- Keep fail-recovery rebuilds independent of the proactive guard so a crashed VM can recover.
- Retire stale rebuild guard registry entries when their current and old generations have expired.
- Add focused regression coverage for active stream accounting, proactive rebuild allow/skip cases, stale registry cleanup, wrapper replacement, same-generation sibling handles, and fail recovery bypass.
- Add the missing `conn_manager_lib` test dependency for `wasm_filter_test`; the same dependency already exists for the common Wasm tests and is needed because `foreign.cc` references symbols defined in `conn_manager_impl.cc`.

## Design Notes

The old guard treated any live old VM handle as a reason to skip the next proactive rebuild. That prevents VM accumulation, but it also blocks reclaiming a high-memory current generation after older slow requests keep an old generation alive.

The new guard separates two states:

- Old generation live + current generation idle: allow proactive rebuild, so the current high-memory VM can be replaced.
- Old generation live + current generation active: skip proactive rebuild, so Envoy does not keep stacking active generations.

Active stream accounting is maintained on `Context` creation and released from `onCloseTCP()`, `onDestroy()`, and the destructor as an idempotent fallback. The registry stores weak references and opportunistically sweeps stale `vm_key` entries.

Fail recovery still calls `rebuild(true)` and bypasses only the proactive active-generation guard. The recover interval still applies as before.

## Verification

Local build config used for verification:

- `clang.bazelrc` copied from `clang-18.bazelrc`
- `user.bazelrc` copied from `user-1.36.bazelrc`

Commands run:

```bash
bazel test //test/extensions/filters/http/wasm:wasm_filter_test --test_filter='*ActiveStreamCounterTracksStreamContextLifetime*:*ProactiveRebuildNoOldGenerationStillSucceeds*:*ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentActive*:*ProactiveRebuildAllowsWhenOldGenerationLiveAndCurrentIdle*:*ProactiveRebuildPrunesExpiredOldGenerations*:*RebuildGuardRegistryRetiresStaleVmKeys*:*NewThreadLocalWrapperKeepsRebuildGuardState*:*ActiveCounterIncludesDifferentPluginHandleOnSameGeneration*:*FailRecoveryBypassesProactiveActiveGuard*'
```

Result: passed. The first run exposed the existing missing `conn_manager_lib` link dependency in `wasm_filter_test`; after adding that dependency, the same focused test passed. A later accidental repeat of the same command also passed.

Additional checks:

```bash
git diff --cached --check
```

Result: passed before commit.

```bash
bazel run //tools/code_format:check_format -- check source/extensions/common/wasm/wasm.h source/extensions/common/wasm/wasm.cc source/extensions/common/wasm/context.h source/extensions/common/wasm/context.cc test/extensions/filters/http/wasm/BUILD test/extensions/filters/http/wasm/wasm_filter_test.cc
```

Result: failed on pre-existing 1.36 formatting/rule debt outside this diff, including the existing runtime-stats formatting in `wasm.cc`, existing `context.h` formatting, existing raw `try` checks in `context.cc`, and existing formatting around `wasm_filter_test.cc` lines 897-1203. The header-order issue introduced during conflict resolution was fixed; `git diff --cached --check` is clean.

## Runtime Experiment Summary

The same change was validated with local Envoy runtime experiments before this port:

- Proactive rebuild plugin: old generation live + current idle allowed a second rebuild; old generation live + current active skipped rebuild with the expected debug log; repeated idle rebuilds did not show sustained RSS growth.
- Ablation: the previous implementation skipped the second proactive rebuild whenever `old_handle_` was live; the optimized implementation allowed it when the current generation was idle while preserving the current-active guard.
- Crash recovery plugin: repeated real Wasm traps recovered automatically on subsequent requests; 10 crash/recover cycles ended with stable active VM counts and `~Wasm 0 remaining active` at shutdown.
