### PR TITLE
wasm: proactively reclaim idle Higress VMs

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1471,6 +1471,7 @@ WasmResult Context::setProperty(std::string_view path, std::string_view value) {
   if (path == WasmRebuildKey) {
     if (wasm_) {
       wasm_->setShouldRebuild(true);
+      wasm()->markReclaimEligible();
       ENVOY_LOG(debug, "Wasm rebuild flag set by plugin");
     }
     return WasmResult::Ok;

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -3,6 +3,9 @@
 #include <memory>
 
 #include "envoy/server/lifecycle_notifier.h"
+#ifdef HIGRESS
+#include "envoy/stats/histogram.h"
+#endif
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -32,14 +35,17 @@ struct CreateWasmStats {
 };
 
 #ifdef HIGRESS
-#define LIFECYCLE_STATS(COUNTER, GAUGE, PLUGIN_COUNTER, PLUGIN_GAUGE)                              \
+#define LIFECYCLE_STATS(COUNTER, GAUGE, PLUGIN_COUNTER, PLUGIN_GAUGE, PLUGIN_HISTOGRAM)            \
   COUNTER(created)                                                                                 \
   GAUGE(active, NeverImport)                                                                       \
   PLUGIN_COUNTER(recover_total)                                                                    \
   PLUGIN_COUNTER(rebuild_total)                                                                    \
+  PLUGIN_COUNTER(rebuild_memory_total)                                                             \
+  PLUGIN_COUNTER(rebuild_periodic_total)                                                           \
   PLUGIN_COUNTER(crash_total)                                                                      \
   PLUGIN_COUNTER(recover_error)                                                                    \
-  PLUGIN_GAUGE(crash, NeverImport)
+  PLUGIN_GAUGE(crash, NeverImport)                                                                 \
+  PLUGIN_HISTOGRAM(reclaim_latency, Milliseconds)
 #else
 #define LIFECYCLE_STATS(COUNTER, GAUGE)                                                            \
   COUNTER(created)                                                                                 \
@@ -47,8 +53,7 @@ struct CreateWasmStats {
 #endif
 
 #ifdef HIGRESS
-#define RUNTIME_STATS(PLUGIN_GAUGE)                                                                \
-  PLUGIN_GAUGE(memory_size, NeverImport)
+#define RUNTIME_STATS(PLUGIN_GAUGE) PLUGIN_GAUGE(memory_size, NeverImport)
 
 struct RuntimeStats {
   RUNTIME_STATS(GENERATE_GAUGE_STRUCT)
@@ -58,7 +63,7 @@ struct RuntimeStats {
 struct LifecycleStats {
 #ifdef HIGRESS
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_COUNTER_STRUCT,
-                  GENERATE_GAUGE_STRUCT)
+                  GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 #else
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 #endif
@@ -128,13 +133,14 @@ public:
             POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")),
             POOL_COUNTER_PREFIX(*scope,
                                 absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")),
-            POOL_GAUGE_PREFIX(*scope,
-                              absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")))}){};
+            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")),
+            POOL_HISTOGRAM_PREFIX(
+                *scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")))}){};
 #else
   LifecycleStatsHandler(const Stats::ScopeSharedPtr& scope, std::string runtime)
       : lifecycle_stats_(LifecycleStats{
             LIFECYCLE_STATS(POOL_COUNTER_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")),
-                            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")))}) {};
+                            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")))}){};
 #endif
   ~LifecycleStatsHandler() = default;
 
@@ -179,16 +185,19 @@ using StatsHandlerSharedPtr = std::shared_ptr<StatsHandler>;
 #ifdef HIGRESS
 class RuntimeStatsHandler {
 public:
-  RuntimeStatsHandler(const Stats::ScopeSharedPtr& scope, const std::string& runtime, const std::string& plugin_name, const std::string& thread_name)
-  : runtime(runtime), plugin_name(plugin_name), runtime_stats_(RuntimeStats{RUNTIME_STATS(POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".", thread_name, ".")))}){}
-  
+  RuntimeStatsHandler(const Stats::ScopeSharedPtr& scope, const std::string& runtime,
+                      const std::string& plugin_name, const std::string& thread_name)
+      : runtime(runtime), plugin_name(plugin_name),
+        runtime_stats_(RuntimeStats{RUNTIME_STATS(
+            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".",
+                                                   thread_name, ".")))}) {}
+
   ~RuntimeStatsHandler() = default;
-  
+
   std::string runtime;
   std::string plugin_name;
-  void updateMemorySize(uint64_t memory_size) {
-    runtime_stats_.memory_size_.set(memory_size);
-  }
+  void updateMemorySize(uint64_t memory_size) { runtime_stats_.memory_size_.set(memory_size); }
+
 protected:
   RuntimeStats runtime_stats_;
 };

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -93,6 +93,13 @@ WasmEvent failStateToWasmEvent(FailState state) {
 }
 
 const int MIN_RECOVER_INTERVAL_SECONDS = 1;
+constexpr uint64_t DefaultReclaimMemoryThresholdBytes = 800ULL * 1024 * 1024;
+constexpr absl::string_view ReclaimMemoryThresholdRuntimeKey =
+    "envoy.wasm.reclaim.memory_threshold_bytes";
+
+MonotonicTime effectiveMonotonicTime(Event::Dispatcher& dispatcher) {
+  return dispatcher.timeSource().monotonicTime() + cache_time_offset_for_testing;
+}
 
 struct RebuildGuardEntry {
   MonotonicTime last_recover_time;
@@ -154,24 +161,54 @@ void sweepRebuildGuardRegistry(const std::string& active_vm_key) {
 } // namespace
 
 #ifdef HIGRESS
-void Wasm::initializeRuntimeStatsTimer(){
+void Wasm::initializeRuntimeStatsTimer() {
   runtime_stats_timer_ = dispatcher_.createTimer(
-  [weak = std::weak_ptr<Wasm>(std::static_pointer_cast<Wasm>(shared_from_this()))]() {
-      auto shared = weak.lock();
-      if (shared) {
-        auto vm = shared->wasm_vm();
-        if (vm) {
-          shared->runtime_stats_handler_.updateMemorySize(vm->getMemorySize());
+      [weak = std::weak_ptr<Wasm>(std::static_pointer_cast<Wasm>(shared_from_this()))]() {
+        auto shared = weak.lock();
+        if (shared) {
+          auto vm = shared->wasm_vm();
+          if (vm) {
+            shared->runtime_stats_handler_.updateMemorySize(vm->getMemorySize());
+          }
+          shared->runtime_stats_timer_->enableTimer(
+              std::chrono::milliseconds(Wasm::kRuntimeStatsInterval));
         }
-        shared->runtime_stats_timer_->enableTimer(std::chrono::milliseconds(Wasm::kRuntimeStatsInterval));
-      }
-    });
+      });
   runtime_stats_timer_->enableTimer(std::chrono::milliseconds(Wasm::kRuntimeStatsInterval));
+}
+
+uint64_t Wasm::reclaimMemoryThreshold() const {
+  if (runtime_loader_ == nullptr) {
+    return DefaultReclaimMemoryThresholdBytes;
+  }
+  const uint64_t threshold = runtime_loader_->snapshot().getInteger(
+      ReclaimMemoryThresholdRuntimeKey, DefaultReclaimMemoryThresholdBytes);
+  return threshold == 0 ? DefaultReclaimMemoryThresholdBytes : threshold;
+}
+
+void Wasm::markReclaimEligible() {
+  if (!reclaim_eligible_since_.has_value()) {
+    reclaim_eligible_since_ = effectiveMonotonicTime(dispatcher_);
+  }
+}
+
+void Wasm::recordReclaimLatency(MonotonicTime now) {
+  if (!reclaim_eligible_since_.has_value()) {
+    return;
+  }
+  const auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - reclaim_eligible_since_.value());
+  lifecycleStats().reclaim_latency_.recordValue(elapsed.count() < 0 ? 0 : elapsed.count());
 }
 #endif
 
 Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeSharedPtr& scope,
-           Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher)
+           Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher
+#ifdef HIGRESS
+           ,
+           Runtime::Loader* runtime
+#endif
+           )
     : WasmBase(
           createWasmVm(config.config().vm_config().runtime()), config.config().vm_config().vm_id(),
           THROW_OR_RETURN_VALUE(
@@ -182,7 +219,9 @@ Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeShare
       cluster_manager_(cluster_manager), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
 #ifdef HIGRESS
-      runtime_stats_handler_(RuntimeStatsHandler(scope, config.config().vm_config().runtime(), config.config().name(), dispatcher.name())),
+      runtime_stats_handler_(RuntimeStatsHandler(scope, config.config().vm_config().runtime(),
+                                                 config.config().name(), dispatcher.name())),
+      runtime_loader_(runtime),
       lifecycle_stats_handler_(LifecycleStatsHandler(scope, config.config().vm_config().runtime(),
                                                      config.config().name())) {
 #else
@@ -193,7 +232,12 @@ Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeShare
   ENVOY_LOG(debug, "Base Wasm created {} now active", lifecycle_stats_handler_.getActiveVmCount());
 }
 
-Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
+Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher
+#ifdef HIGRESS
+           ,
+           Runtime::Loader* runtime
+#endif
+           )
     : WasmBase(base_wasm_handle,
                [&base_wasm_handle]() {
                  return createWasmVm(absl::StrCat(
@@ -206,7 +250,11 @@ Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
       cluster_manager_(getWasm(base_wasm_handle)->clusterManager()), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
 #ifdef HIGRESS
-      runtime_stats_handler_(RuntimeStatsHandler(getWasm(base_wasm_handle)->scope_, getWasm(base_wasm_handle)->runtime_stats_handler_.runtime, getWasm(base_wasm_handle)->runtime_stats_handler_.plugin_name, dispatcher.name())), 
+      runtime_stats_handler_(RuntimeStatsHandler(
+          getWasm(base_wasm_handle)->scope_,
+          getWasm(base_wasm_handle)->runtime_stats_handler_.runtime,
+          getWasm(base_wasm_handle)->runtime_stats_handler_.plugin_name, dispatcher.name())),
+      runtime_loader_(runtime != nullptr ? runtime : getWasm(base_wasm_handle)->runtime_loader_),
 #endif
       lifecycle_stats_handler_(getWasm(base_wasm_handle)->lifecycle_stats_handler_) {
   lifecycle_stats_handler_.onEvent(WasmEvent::VmCreated);
@@ -271,51 +319,160 @@ Wasm::~Wasm() {
 }
 
 #if defined(HIGRESS)
-bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery) {
-  if (handle == nullptr || handle->wasmHandle() == nullptr ||
-      handle->wasmHandle()->wasm() == nullptr) {
+PluginHandleSharedPtrThreadLocal::PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle,
+                                                                   WasmHandleSharedPtr base_wasm,
+                                                                   bool enable_reclaim_timer,
+                                                                   MonotonicTime last_load)
+    : last_load(last_load),
+      plugin_(handle != nullptr ? std::static_pointer_cast<Plugin>(handle->plugin()) : nullptr),
+      base_wasm_(base_wasm), reclaim_timer_enabled_(enable_reclaim_timer),
+      handle_(std::move(handle)) {
+  initializeReclaimTimer();
+}
+
+PluginHandleSharedPtrThreadLocal::~PluginHandleSharedPtrThreadLocal() {
+  if (reclaim_timer_) {
+    reclaim_timer_->disableTimer();
+  }
+}
+
+void PluginHandleSharedPtrThreadLocal::initializeReclaimTimer() {
+  if (!reclaim_timer_enabled_) {
+    return;
+  }
+  if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
+      handle_->wasmHandle()->wasm() == nullptr) {
+    return;
+  }
+  reclaim_timer_ =
+      handle_->wasmHandle()->wasm()->dispatcher().createTimer([this]() { onReclaimTimer(); });
+  reclaim_timer_->enableTimer(kReclaimTimerInterval);
+}
+
+void PluginHandleSharedPtrThreadLocal::runReclaimTimerForTesting() { onReclaimTimer(); }
+
+void PluginHandleSharedPtrThreadLocal::onReclaimTimer() {
+  auto rearm = [this]() {
+    if (reclaim_timer_) {
+      reclaim_timer_->enableTimer(kReclaimTimerInterval);
+    }
+  };
+
+  if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
+      handle_->wasmHandle()->wasm() == nullptr) {
+    rearm();
+    return;
+  }
+
+  auto wasm = handle_->wasmHandle()->wasm();
+  const uint64_t memory_size = wasm->wasm_vm() != nullptr ? wasm->wasm_vm()->getMemorySize() : 0;
+  const bool memory_triggered = memory_size > wasm->reclaimMemoryThreshold();
+  const bool periodic_triggered = wasm->shouldRebuild();
+  if (!memory_triggered && !periodic_triggered) {
+    rearm();
+    return;
+  }
+
+  RebuildSource source = RebuildSource::Periodic;
+  if (memory_triggered) {
+    source = RebuildSource::Memory;
+    wasm->markReclaimEligible();
+    wasm->setShouldRebuild(true);
+  } else {
+    wasm->markReclaimEligible();
+  }
+
+  rebuild(false, source);
+  if (memory_triggered) {
+    wasm->setShouldRebuild(false);
+  }
+  rearm();
+}
+
+bool PluginHandleSharedPtrThreadLocal::syncHandleToCurrentGeneration(const std::string& vm_key) {
+  auto current_base = proxy_wasm::getThreadLocalWasm(vm_key);
+  if (current_base == nullptr) {
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: no current generation for vm_key");
+    return false;
+  }
+  auto current_wasm_handle = std::static_pointer_cast<WasmHandle>(current_base);
+  if (handle_ != nullptr && handle_->wasmHandle() != nullptr &&
+      handle_->wasmHandle().get() == current_wasm_handle.get()) {
+    return true;
+  }
+  if (base_wasm_ != nullptr && plugin_ != nullptr) {
+    auto synced_handle = getOrCreateThreadLocalPlugin(base_wasm_, plugin_,
+                                                      current_wasm_handle->wasm()->dispatcher());
+    if (synced_handle != nullptr && synced_handle->wasmHandle() != nullptr &&
+        synced_handle->wasmHandle().get() == current_wasm_handle.get()) {
+      handle_ = synced_handle;
+      ENVOY_LOG(info, "wasm vm proactive rebuild skipped: stale wrapper synchronized to current "
+                      "generation");
+      return false;
+    }
+  }
+  ENVOY_LOG(info, "wasm vm proactive rebuild skipped: stale wrapper has no current plugin handle");
+  return false;
+}
+
+bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery, RebuildSource source) {
+  if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
+      handle_->wasmHandle()->wasm() == nullptr) {
     ENVOY_LOG(warn, "wasm has not been initialized");
     return false;
   }
-  auto current_wasm_handle = handle->wasmHandle();
+  auto current_wasm_handle = handle_->wasmHandle();
   auto current_wasm = current_wasm_handle->wasm();
   const std::string vm_key(current_wasm->vm_key());
+  if (!is_fail_recovery && !syncHandleToCurrentGeneration(vm_key)) {
+    return false;
+  }
+  current_wasm_handle = handle_->wasmHandle();
+  current_wasm = current_wasm_handle->wasm();
   sweepRebuildGuardRegistry(vm_key);
   auto& guard = rebuild_guard_registry[vm_key];
   guard.trackCurrentGeneration(current_wasm_handle);
   auto& dispatcher = current_wasm->dispatcher();
-  auto now = dispatcher.timeSource().monotonicTime() + cache_time_offset_for_testing;
+  auto now = effectiveMonotonicTime(dispatcher);
   if (now - guard.last_recover_time < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
     ENVOY_LOG(info, "wasm vm rebuild skipped: recover interval has not been reached");
     return false;
   }
   if (!is_fail_recovery && guard.hasLiveOldGeneration(current_wasm_handle)) {
-    const auto active_stream_count = current_wasm->activeStreamCount();
-    if (active_stream_count > 0) {
-      ENVOY_LOG(info,
-                "wasm vm proactive rebuild skipped: old generation is still live and current "
-                "generation has {} active streams",
-                active_stream_count);
-      return false;
-    }
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: live generation cap reached");
+    return false;
+  }
+  const auto active_stream_count = current_wasm->activeStreamCount();
+  if (!is_fail_recovery && active_stream_count > 0) {
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: current generation has {} active streams",
+              active_stream_count);
+    return false;
   }
   // Even if rebuild fails, it will be retried after the interval
   guard.last_recover_time = now;
   std::shared_ptr<PluginHandleBase> new_handle;
-  if (handle->rebuild(new_handle) && new_handle != nullptr) {
+  if (handle_->rebuild(new_handle) && new_handle != nullptr) {
     auto new_plugin_handle = std::static_pointer_cast<PluginHandle>(new_handle);
     auto new_wasm_handle = new_plugin_handle->wasmHandle();
     if (new_wasm_handle != nullptr && new_wasm_handle.get() != current_wasm_handle.get()) {
       guard.trackOldGeneration(current_wasm_handle);
     }
     guard.trackCurrentGeneration(new_wasm_handle);
-    handle = new_plugin_handle;
+    handle_ = new_plugin_handle;
     // Increment appropriate metrics based on rebuild type
     if (is_fail_recovery) {
-      handle->wasmHandle()->wasm()->lifecycleStats().recover_total_.inc();
+      handle_->wasmHandle()->wasm()->lifecycleStats().recover_total_.inc();
       ENVOY_LOG(info, "wasm vm recover from crash success");
     } else {
-      handle->wasmHandle()->wasm()->lifecycleStats().rebuild_total_.inc();
+      auto& stats = handle_->wasmHandle()->wasm()->lifecycleStats();
+      stats.rebuild_total_.inc();
+      if (source == RebuildSource::Memory) {
+        stats.rebuild_memory_total_.inc();
+      } else {
+        stats.rebuild_periodic_total_.inc();
+      }
+      current_wasm->recordReclaimLatency(now);
+      current_wasm->clearReclaimEligible();
       ENVOY_LOG(info, "wasm vm rebuild success");
     }
     return true;
@@ -437,11 +594,25 @@ void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d) {
 static proxy_wasm::WasmHandleFactory
 getWasmHandleFactory(WasmConfig& wasm_config, const Stats::ScopeSharedPtr& scope, Api::Api& api,
                      Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher,
-                     Server::ServerLifecycleNotifier&) {
-  return [&wasm_config, &scope, &api, &cluster_manager,
-          &dispatcher](std::string_view vm_key) -> WasmHandleBaseSharedPtr {
+                     Server::ServerLifecycleNotifier&
+#if defined(HIGRESS)
+                     ,
+                     Runtime::Loader* runtime
+#endif
+) {
+  return [&wasm_config, &scope, &api, &cluster_manager, &dispatcher
+#if defined(HIGRESS)
+          ,
+          runtime
+#endif
+  ](std::string_view vm_key) -> WasmHandleBaseSharedPtr {
     auto wasm = std::make_shared<Wasm>(wasm_config, toAbslStringView(vm_key), scope, api,
-                                       cluster_manager, dispatcher);
+                                       cluster_manager, dispatcher
+#if defined(HIGRESS)
+                                       ,
+                                       runtime
+#endif
+    );
     return std::static_pointer_cast<WasmHandleBase>(std::make_shared<WasmHandle>(std::move(wasm)));
   };
 }
@@ -506,7 +677,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
                 Event::Dispatcher& dispatcher, Api::Api& api,
                 Server::ServerLifecycleNotifier& lifecycle_notifier,
                 RemoteAsyncDataProviderPtr& remote_data_provider, CreateWasmCallback&& cb,
-                CreateContextFn create_root_context_for_testing) {
+                CreateContextFn create_root_context_for_testing
+#if defined(HIGRESS)
+                ,
+                Runtime::Loader* runtime
+#endif
+) {
   auto& stats_handler = getCreateStatsHandler();
   std::string source, code;
   auto config = plugin->wasmConfig();
@@ -576,6 +752,9 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
       vm_config.vm_id(),
       THROW_OR_RETURN_VALUE(MessageUtil::anyToBytes(vm_config.configuration()), std::string), code);
   auto complete_cb = [cb, vm_key, plugin, scope, &api, &cluster_manager, &dispatcher,
+#if defined(HIGRESS)
+                      runtime,
+#endif
                       &lifecycle_notifier, create_root_context_for_testing,
                       &stats_handler](std::string code) -> bool {
     if (code.empty()) {
@@ -586,7 +765,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
     auto config = plugin->wasmConfig();
     auto wasm = proxy_wasm::createWasm(
         vm_key, code, plugin,
-        getWasmHandleFactory(config, scope, api, cluster_manager, dispatcher, lifecycle_notifier),
+        getWasmHandleFactory(config, scope, api, cluster_manager, dispatcher, lifecycle_notifier
+#if defined(HIGRESS)
+                             ,
+                             runtime
+#endif
+                             ),
         getWasmHandleCloneFactory(dispatcher, create_root_context_for_testing),
         config.config().vm_config().allow_precompiled());
     Stats::ScopeSharedPtr create_wasm_stats_scope = stats_handler.lockAndCreateStats(scope);
@@ -685,28 +869,11 @@ Wasm* PluginConfig::maybeReloadHandleIfNeeded(SinglePluginHandle& handle_wrapper
   }
 
   // Null handle is special case and won't be reloaded for backward compatibility.
-  if (handle_wrapper.handle == nullptr) {
+  if (handle_wrapper.handle() == nullptr) {
     return nullptr;
   }
 
-  Wasm* wasm = getWasmOrNull(handle_wrapper.handle->wasmHandle());
-
-#if defined(HIGRESS)
-  // Check if plugin requested a rebuild (e.g., for memory optimization)
-  if (wasm != nullptr && !wasm->isFailed() && wasm->shouldRebuild()) {
-    ENVOY_LOG(info, "wasm vm requested rebuild, try to rebuild");
-    if (handle_wrapper.rebuild(false)) {
-      ENVOY_LOG(info, "wasm vm rebuild success");
-      wasm = getWasmOrNull(handle_wrapper.handle->wasmHandle());
-      if (wasm != nullptr) {
-        wasm->setShouldRebuild(false);
-      }
-    } else {
-      ENVOY_LOG(info, "wasm vm rebuild failed, still using the stale one");
-    }
-    return wasm;
-  }
-#endif
+  Wasm* wasm = getWasmOrNull(handle_wrapper.handle()->wasmHandle());
 
   // Only runtime failure will be handled by reloading logic. If the wasm is not failed or
   // failed with other errors, return it directly.
@@ -741,14 +908,14 @@ Wasm* PluginConfig::maybeReloadHandleIfNeeded(SinglePluginHandle& handle_wrapper
       stats_handler_->onEvent(WasmEvent::VmReloadFailure);
     } else {
       stats_handler_->onEvent(WasmEvent::VmReloadSuccess);
-      handle_wrapper.handle = new_load;
+      handle_wrapper.handle() = new_load;
     }
   } else {
     stats_handler_->onEvent(WasmEvent::VmReloadFailure);
   }
 
-  ASSERT(handle_wrapper.handle != nullptr);
-  return getWasmOrNull(handle_wrapper.handle->wasmHandle());
+  ASSERT(handle_wrapper.handle() != nullptr);
+  return getWasmOrNull(handle_wrapper.handle()->wasmHandle());
 }
 
 std::pair<OptRef<PluginConfig::SinglePluginHandle>, Wasm*> PluginConfig::getPluginHandleAndWasm() {
@@ -833,8 +1000,12 @@ PluginConfig::PluginConfig(const envoy::extensions::wasm::v3::PluginConfig& conf
     }
 
     if (is_singleton_handle_) {
-      plugin_handle_ = SinglePluginHandle(
-          getOrCreateThreadLocalPlugin(base_wasm, plugin_, context.mainThreadDispatcher()),
+      plugin_handle_.emplace<SinglePluginHandle>(
+          getOrCreateThreadLocalPlugin(base_wasm, plugin_, context.mainThreadDispatcher())
+#if defined(HIGRESS)
+              ,
+          base_wasm, true,
+#endif
           context.mainThreadDispatcher().timeSource().monotonicTime());
       return;
     }
@@ -844,7 +1015,11 @@ PluginConfig::PluginConfig(const envoy::extensions::wasm::v3::PluginConfig& conf
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     thread_local_handle->set([base_wasm, plugin = this->plugin_](Event::Dispatcher& dispatcher) {
       return std::make_shared<SinglePluginHandle>(
-          getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher),
+          getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher)
+#if defined(HIGRESS)
+              ,
+          base_wasm, true,
+#endif
           dispatcher.timeSource().monotonicTime());
     });
     plugin_handle_ = std::move(thread_local_handle);
@@ -853,7 +1028,12 @@ PluginConfig::PluginConfig(const envoy::extensions::wasm::v3::PluginConfig& conf
   if (!Common::Wasm::createWasm(plugin_, scope.createScope(""), context.clusterManager(),
                                 init_manager, context.mainThreadDispatcher(), context.api(),
                                 context.lifecycleNotifier(), remote_data_provider_,
-                                std::move(callback))) {
+                                std::move(callback)
+#if defined(HIGRESS)
+                                    ,
+                                nullptr, &context.runtime()
+#endif
+                                    )) {
     // TODO(wbpcode): use absl::Status to return error rather than throw.
     throw Common::Wasm::WasmException(
         fmt::format("Unable to create Wasm plugin {}", plugin_->name_));
@@ -862,7 +1042,7 @@ PluginConfig::PluginConfig(const envoy::extensions::wasm::v3::PluginConfig& conf
 
 std::shared_ptr<Context> PluginConfig::createContext() {
   auto [plugin_handle_holder, wasm] = getPluginHandleAndWasm();
-  if (!plugin_handle_holder.has_value() || plugin_handle_holder->handle == nullptr) {
+  if (!plugin_handle_holder.has_value() || plugin_handle_holder->handle() == nullptr) {
     return nullptr;
   }
 
@@ -874,11 +1054,11 @@ std::shared_ptr<Context> PluginConfig::createContext() {
       return nullptr;
     } else {
       // Fail closed is handled by an empty Context.
-      return std::make_shared<Context>(nullptr, 0, plugin_handle_holder->handle);
+      return std::make_shared<Context>(nullptr, 0, plugin_handle_holder->handle());
     }
   }
-  return std::make_shared<Context>(wasm, plugin_handle_holder->handle->rootContextId(),
-                                   plugin_handle_holder->handle);
+  return std::make_shared<Context>(wasm, plugin_handle_holder->handle()->rootContextId(),
+                                   plugin_handle_holder->handle());
 }
 
 Wasm* PluginConfig::wasm() { return getPluginHandleAndWasm().second; }

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -9,6 +9,9 @@
 #include "envoy/extensions/wasm/v3/wasm.pb.h"
 #include "envoy/extensions/wasm/v3/wasm.pb.validate.h"
 #include "envoy/http/filter.h"
+#if defined(HIGRESS)
+#include "envoy/runtime/runtime.h"
+#endif
 #include "envoy/server/lifecycle_notifier.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
@@ -29,6 +32,10 @@
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/wasm.h"
 
+#if defined(HIGRESS)
+#include "absl/types/optional.h"
+#endif
+
 namespace Envoy {
 namespace Extensions {
 namespace Common {
@@ -44,8 +51,18 @@ class WasmHandle;
 class Wasm : public WasmBase, Logger::Loggable<Logger::Id::wasm> {
 public:
   Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeSharedPtr& scope,
-       Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher);
-  Wasm(std::shared_ptr<WasmHandle> other, Event::Dispatcher& dispatcher);
+       Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher
+#if defined(HIGRESS)
+       ,
+       Runtime::Loader* runtime = nullptr
+#endif
+  );
+  Wasm(std::shared_ptr<WasmHandle> other, Event::Dispatcher& dispatcher
+#if defined(HIGRESS)
+       ,
+       Runtime::Loader* runtime = nullptr
+#endif
+  );
   ~Wasm() override;
 
   Upstream::ClusterManager& clusterManager() const { return cluster_manager_; }
@@ -78,6 +95,12 @@ public:
 
 #if defined(HIGRESS)
   void initializeRuntimeStatsTimer();
+  uint64_t reclaimMemoryThreshold() const;
+  void markReclaimEligible();
+  void clearReclaimEligible() { reclaim_eligible_since_.reset(); }
+  const absl::optional<MonotonicTime>& reclaimEligibleSinceForTesting() const {
+    return reclaim_eligible_since_;
+  }
 #endif
 
   uint32_t nextDnsToken() {
@@ -96,6 +119,7 @@ public:
 
 #if defined(HIGRESS)
   LifecycleStats& lifecycleStats() { return lifecycle_stats_handler_.stats(); }
+  void recordReclaimLatency(MonotonicTime now);
   void incrementActiveStreamCount() { ++active_stream_count_; }
   void decrementActiveStreamCount() {
     ASSERT(active_stream_count_ > 0);
@@ -131,6 +155,8 @@ protected:
   Event::TimerPtr runtime_stats_timer_;
   static constexpr std::chrono::milliseconds kRuntimeStatsInterval{1000};
   uint64_t active_stream_count_ = 0;
+  Runtime::Loader* runtime_loader_;
+  absl::optional<MonotonicTime> reclaim_eligible_since_;
 #endif
 
   // Lifecycle stats
@@ -182,27 +208,47 @@ private:
 using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;
 
 #if defined(HIGRESS)
+enum class RebuildSource { Periodic, Memory };
+
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject,
                                          public Logger::Loggable<Logger::Id::wasm> {
 public:
-  PluginHandleSharedPtr handle{};
   MonotonicTime last_load{};
 
-  PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr h, MonotonicTime t = {})
-      : handle(std::move(h)), last_load(t) {}
+  PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle,
+                                   WasmHandleSharedPtr base_wasm = nullptr,
+                                   bool enable_reclaim_timer = false, MonotonicTime last_load = {});
   PluginHandleSharedPtrThreadLocal() = default;
+  ~PluginHandleSharedPtrThreadLocal() override;
 
-  bool rebuild(bool is_fail_recovery = false);
+  bool rebuild(bool is_fail_recovery = false, RebuildSource source = RebuildSource::Periodic);
+  void runReclaimTimerForTesting();
+  PluginHandleSharedPtr& handle() { return handle_; }
+
+private:
+  void initializeReclaimTimer();
+  void onReclaimTimer();
+  bool syncHandleToCurrentGeneration(const std::string& vm_key);
+
+  PluginSharedPtr plugin_;
+  WasmHandleSharedPtr base_wasm_;
+  Event::TimerPtr reclaim_timer_;
+  bool reclaim_timer_enabled_{};
+  static constexpr std::chrono::milliseconds kReclaimTimerInterval{1000};
+  PluginHandleSharedPtr handle_{};
 };
 #else
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject {
 public:
-  PluginHandleSharedPtr handle{};
   MonotonicTime last_load{};
 
   PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr h, MonotonicTime t = {})
-      : handle(std::move(h)), last_load(t) {}
+      : last_load(t), handle_(std::move(h)) {}
   PluginHandleSharedPtrThreadLocal() = default;
+  PluginHandleSharedPtr& handle() { return handle_; }
+
+private:
+  PluginHandleSharedPtr handle_{};
 };
 #endif
 
@@ -217,7 +263,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
                 Event::Dispatcher& dispatcher, Api::Api& api,
                 Server::ServerLifecycleNotifier& lifecycle_notifier,
                 RemoteAsyncDataProviderPtr& remote_data_provider, CreateWasmCallback&& callback,
-                CreateContextFn create_root_context_for_testing = nullptr);
+                CreateContextFn create_root_context_for_testing = nullptr
+#if defined(HIGRESS)
+                ,
+                Runtime::Loader* runtime = nullptr
+#endif
+);
 
 PluginHandleSharedPtr
 getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginSharedPtr& plugin,

--- a/test/extensions/filters/http/wasm/BUILD
+++ b/test/extensions/filters/http/wasm/BUILD
@@ -70,6 +70,7 @@ envoy_extension_cc_test(
         "//source/common/common:base64_lib",
         "//source/common/common:hex_lib",
         "//source/common/crypto:utility_lib",
+        "//source/common/http:conn_manager_lib",
         "//source/common/http:message_lib",
         "//source/extensions/common/wasm:wasm_lib",
         "//source/extensions/filters/http/wasm:config",

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -40,6 +40,9 @@ using Envoy::Extensions::Common::Wasm::Plugin;
 using Envoy::Extensions::Common::Wasm::PluginHandle;
 using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtr;
 using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtrThreadLocal;
+#if defined(HIGRESS)
+using Envoy::Extensions::Common::Wasm::RebuildSource;
+#endif
 using Envoy::Extensions::Common::Wasm::Wasm;
 using Envoy::Extensions::Common::Wasm::WasmHandleSharedPtr;
 using proxy_wasm::ContextBase;
@@ -108,21 +111,33 @@ public:
   }
 
   bool rebuildThroughThreadLocal(PluginHandleSharedPtrThreadLocal& thread_local_handle,
-                                 bool is_fail_recovery = false) {
-    if (!is_fail_recovery && thread_local_handle.handle != nullptr &&
-        thread_local_handle.handle->wasmHandle() != nullptr &&
-        thread_local_handle.handle->wasmHandle()->wasm() != nullptr) {
-      thread_local_handle.handle->wasmHandle()->wasm()->setShouldRebuild(true);
+                                 bool is_fail_recovery = false,
+                                 RebuildSource source = RebuildSource::Periodic) {
+    if (!is_fail_recovery && thread_local_handle.handle() != nullptr &&
+        thread_local_handle.handle()->wasmHandle() != nullptr &&
+        thread_local_handle.handle()->wasmHandle()->wasm() != nullptr) {
+      thread_local_handle.handle()->wasmHandle()->wasm()->setShouldRebuild(true);
     }
-    const bool rebuilt = thread_local_handle.rebuild(is_fail_recovery);
+    const bool rebuilt = thread_local_handle.rebuild(is_fail_recovery, source);
     if (rebuilt) {
-      plugin_handle_ = thread_local_handle.handle;
+      plugin_handle_ = thread_local_handle.handle();
       wasm_ = plugin_handle_->wasmHandle();
       if (!is_fail_recovery && wasm_ != nullptr && wasm_->wasm() != nullptr) {
         wasm_->wasm()->setShouldRebuild(false);
       }
     }
     return rebuilt;
+  }
+
+  std::unique_ptr<PluginHandleSharedPtrThreadLocal>
+  makeThreadLocalHandle(bool enable_reclaim_timer = false) {
+    return std::make_unique<PluginHandleSharedPtrThreadLocal>(plugin_handle_, base_wasm_,
+                                                              enable_reclaim_timer);
+  }
+
+  void adoptThreadLocalHandle(PluginHandleSharedPtrThreadLocal& thread_local_handle) {
+    plugin_handle_ = thread_local_handle.handle();
+    wasm_ = plugin_handle_->wasmHandle();
   }
 
   std::unique_ptr<TestFilter> makeStreamContext(const PluginHandleSharedPtr& plugin_handle) {
@@ -2203,18 +2218,18 @@ TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentA
 
   auto current_stream_context = makeStreamContext(plugin_handle_);
   EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
-  PluginHandleSharedPtr current_generation_handle = thread_local_handle.handle;
+  PluginHandleSharedPtr current_generation_handle = thread_local_handle.handle();
 
   advanceRebuildInterval();
   EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
-  EXPECT_EQ(current_generation_handle.get(), thread_local_handle.handle.get());
+  EXPECT_EQ(current_generation_handle.get(), thread_local_handle.handle().get());
   EXPECT_EQ(1U, rebuild_total.value());
 
   current_stream_context->onDestroy();
   EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
 }
 
-TEST_P(WasmHttpFilterTest, ProactiveRebuildAllowsWhenOldGenerationLiveAndCurrentIdle) {
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentIdle) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {
     return;
@@ -2237,11 +2252,38 @@ TEST_P(WasmHttpFilterTest, ProactiveRebuildAllowsWhenOldGenerationLiveAndCurrent
   EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
 
   advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  old_generation_handle.reset();
+
+  advanceRebuildInterval();
   EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
   EXPECT_EQ(2U, rebuild_total.value());
 }
 
-TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenCurrentGenerationActiveWithoutOld) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {
     return;
@@ -2263,8 +2305,8 @@ TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
   EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
 
   advanceRebuildInterval();
-  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
-  EXPECT_EQ(2U, rebuild_total.value());
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
 
   current_stream_context->onDestroy();
 }
@@ -2392,6 +2434,188 @@ TEST_P(WasmHttpFilterTest, FailRecoveryBypassesProactiveActiveGuard) {
   EXPECT_EQ(1U, recover_total.value());
 
   current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerRebuildsIdleVmWhenShouldRebuildIsSet) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& rebuild_periodic_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_periodic_total");
+  auto& rebuild_memory_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto old_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  old_wasm->setShouldRebuild(true);
+  old_wasm->markReclaimEligible();
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(1U, rebuild_periodic_total.value());
+  EXPECT_EQ(0U, rebuild_memory_total.value());
+  EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerUsesMemoryThresholdSourceAndRuntimeOverride) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& rebuild_periodic_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_periodic_total");
+  auto& rebuild_memory_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("envoy.wasm.reclaim.memory_threshold_bytes", 800ULL * 1024 * 1024))
+      .WillRepeatedly(Return(1));
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto old_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  EXPECT_FALSE(old_wasm->shouldRebuild());
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, rebuild_periodic_total.value());
+  EXPECT_EQ(1U, rebuild_memory_total.value());
+  EXPECT_FALSE(old_wasm->shouldRebuild());
+  EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimMemoryThresholdFallsBackWhenRuntimeValueIsZero) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("envoy.wasm.reclaim.memory_threshold_bytes", 800ULL * 1024 * 1024))
+      .WillOnce(Return(0));
+  EXPECT_EQ(800ULL * 1024 * 1024, wasm_->wasm()->reclaimMemoryThreshold());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerSkipKeepsEligibleSinceUntilSuccessfulReclaim) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto stream_context = makeStreamContext(plugin_handle_);
+  auto wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  wasm->setShouldRebuild(true);
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+
+  EXPECT_EQ(0U, rebuild_total.value());
+  EXPECT_TRUE(wasm->reclaimEligibleSinceForTesting().has_value());
+
+  stream_context->onDestroy();
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_FALSE(wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerStillHonorsRecoverInterval) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  thread_local_handle->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  thread_local_handle->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  thread_local_handle->runReclaimTimerForTesting();
+  EXPECT_EQ(1U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerDoesNotCrashForEmptyHandle) {
+  PluginHandleSharedPtrThreadLocal thread_local_handle(nullptr, nullptr, true);
+  thread_local_handle.runReclaimTimerForTesting();
+}
+
+TEST_P(WasmHttpFilterTest, StaleWrapperSynchronizesToHostCurrentBeforeReclaim) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto wrapper_a = makeThreadLocalHandle(true);
+  auto wrapper_b = makeThreadLocalHandle(true);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(*wrapper_a));
+  adoptThreadLocalHandle(*wrapper_a);
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  advanceRebuildInterval();
+  wrapper_b->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  EXPECT_FALSE(wrapper_b->rebuild(false));
+  EXPECT_EQ(plugin_handle_.get(), wrapper_b->handle().get());
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  advanceRebuildInterval();
+  wrapper_b->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  EXPECT_TRUE(rebuildThroughThreadLocal(*wrapper_b));
+  adoptThreadLocalHandle(*wrapper_b);
+  EXPECT_EQ(2U, rebuild_total.value());
 }
 
 TEST_P(WasmHttpFilterTest, RecoverFromCrash) {

--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -14,6 +14,9 @@
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#if defined(HIGRESS)
+#include "test/mocks/runtime/mocks.h"
+#endif
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
@@ -88,7 +91,12 @@ public:
     // Passes ownership of root_context_.
     Extensions::Common::Wasm::createWasm(
         plugin_, scope_, cluster_manager_, init_manager_, dispatcher_, *api, lifecycle_notifier_,
-        remote_data_provider_, [this](WasmHandleSharedPtr wasm) { base_wasm_ = wasm; }, create_root);
+        remote_data_provider_, [this](WasmHandleSharedPtr wasm) { base_wasm_ = wasm; }, create_root
+#if defined(HIGRESS)
+        ,
+        &runtime_
+#endif
+    );
     plugin_handle_ = getOrCreateThreadLocalPlugin(
         base_wasm_, plugin_, dispatcher_,
         [this, create_root](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) {
@@ -108,6 +116,9 @@ public:
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   NiceMock<Init::MockManager> init_manager_;
+#if defined(HIGRESS)
+  NiceMock<Runtime::MockLoader> runtime_;
+#endif
   WasmHandleSharedPtr base_wasm_; // Keep base_wasm alive for recover callback
   WasmHandleSharedPtr wasm_;
   PluginSharedPtr plugin_;


### PR DESCRIPTION
## Summary

Port the proactive Higress Wasm VM reclaim change to the open-source Envoy 1.36 fork.

This adds a worker-local reclaim timer for Higress Wasm plugin handles so idle VMs can be rebuilt without waiting for the next request, supports memory-threshold driven reclaim via `envoy.wasm.reclaim.memory_threshold_bytes`, centralizes proactive rebuild guards, keeps request-path non-fail rebuilds out of filter creation, and exposes source counters plus reclaim latency.

OpenSpec files and experiment artifacts are intentionally not included in this open-source PR.

## Verification

- `bazel test //test/extensions/filters/http/wasm:wasm_filter_test //test/extensions/common/wasm:wasm_test //test/extensions/filters/http/wasm:config_test --test_output=errors` passed.
- `bazel build //source/exe:envoy-static` passed.
- Config validate passed for timer-reclaim, fail-recovery, and rendered file-ECDS configs using the current `bazel-bin/source/exe/envoy-static`.
- Runtime timer/memory/active/leak experiment passed:
  - active request guard skipped rebuild while a request was held;
  - timer-only `wasm_need_rebuild` rebuilt without another data request;
  - memory-threshold reclaim incremented `rebuild_memory_total` and returned memory gauges to baseline;
  - `rebuild_total = rebuild_periodic_total + rebuild_memory_total`;
  - `reclaim_latency_count = rebuild_total`;
  - shutdown logged `~Wasm 0 remaining active`.
- Runtime FAIL_RELOAD crash/reload experiment passed: `crash_total=3`, `vm_reload_success=3`, `vm_reload_failure=0`, shutdown released all Wasm VMs.
- File-ECDS `cp tmp && mv` update experiment passed:
  - same-`vm_key` plugin config update preserved pending reclaim state;
  - Wasm binary A/B update switched naturally without proactive rebuild counters;
  - pending rebuild plus binary update stayed bounded to 0..1 rebuild;
  - held in-flight v4/B request completed on old VM while new requests used v5/A;
  - 12-cycle rebuild/binary churn resource soak passed with bounded RSS/fd/server memory;
  - new-`vm_key` update still allowed memory-threshold reclaim;
  - final active VM count returned to baseline and shutdown released all VMs.
- `git diff --check` passed.
- `git clang-format --diff higress/envoy-1.36 -- <touched C++/header files>` reported no changes.

Local format tool notes:

- `tools/code_format/check_format.py check ...` is blocked by local Python syntax support (`TypeError: 'type' object is not subscriptable` for `list[str]`).
- `buildifier` is not installed in this environment; the BUILD diff only adds one sorted dependency entry.
