### PR TITLE
wasm: proactively reclaim idle Higress VMs

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -181,7 +181,28 @@ Context::Context(Wasm* wasm, const PluginSharedPtr& plugin) : ContextBase(wasm, 
   root_local_info_ = &std::static_pointer_cast<Plugin>(plugin)->localInfo();
 }
 Context::Context(Wasm* wasm, uint32_t root_context_id, PluginHandleSharedPtr plugin_handle)
-    : ContextBase(wasm, root_context_id, plugin_handle), plugin_handle_(plugin_handle) {}
+    : ContextBase(wasm, root_context_id, plugin_handle), plugin_handle_(plugin_handle) {
+#if defined(HIGRESS)
+  if (wasm != nullptr && plugin_handle_ != nullptr && plugin_handle_->wasmHandle() != nullptr &&
+      plugin_handle_->wasmHandle()->wasm() != nullptr) {
+    plugin_handle_->wasmHandle()->wasm()->incrementActiveStreamCount();
+    active_stream_count_recorded_ = true;
+  }
+#endif
+}
+
+#if defined(HIGRESS)
+void Context::releaseActiveStream() {
+  if (!active_stream_count_recorded_) {
+    return;
+  }
+  active_stream_count_recorded_ = false;
+  if (plugin_handle_ != nullptr && plugin_handle_->wasmHandle() != nullptr &&
+      plugin_handle_->wasmHandle()->wasm() != nullptr) {
+    plugin_handle_->wasmHandle()->wasm()->decrementActiveStreamCount();
+  }
+}
+#endif
 
 Wasm* Context::wasm() const { return static_cast<Wasm*>(wasm_); }
 Plugin* Context::plugin() const { return static_cast<Plugin*>(plugin_.get()); }
@@ -204,8 +225,14 @@ uint64_t Context::getMonotonicTimeNanoseconds() {
 
 void Context::onCloseTCP() {
   if (tcp_connection_closed_ || !in_vm_context_created_) {
+#if defined(HIGRESS)
+    releaseActiveStream();
+#endif
     return;
   }
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   tcp_connection_closed_ = true;
   onDone();
   onLog();
@@ -1436,6 +1463,7 @@ WasmResult Context::setProperty(std::string_view path, std::string_view value) {
   if (path == WasmRebuildKey) {
     if (wasm_) {
       wasm_->setShouldRebuild(true);
+      wasm()->markReclaimEligible();
       ENVOY_LOG(debug, "Wasm rebuild flag set by plugin");
     }
     return WasmResult::Ok;
@@ -1658,6 +1686,9 @@ WasmResult Context::getMetric(uint32_t metric_id, uint64_t* result_uint64_ptr) {
 }
 
 Context::~Context() {
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   // Cancel any outstanding requests.
   for (auto& p : http_request_) {
     p.second.request_->cancel();
@@ -1844,6 +1875,9 @@ void Context::log(const Http::RequestHeaderMap* request_headers,
 }
 
 void Context::onDestroy() {
+#if defined(HIGRESS)
+  releaseActiveStream();
+#endif
   if (destroyed_ || !in_vm_context_created_) {
     return;
   }

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -320,6 +320,9 @@ protected:
 
   void addAfterVmCallAction(std::function<void()> f);
   void onCloseTCP();
+#if defined(HIGRESS)
+  void releaseActiveStream();
+#endif
 
   struct AsyncClientHandler : public Http::AsyncClient::Callbacks {
     // Http::AsyncClient::Callbacks
@@ -422,6 +425,9 @@ protected:
 
   const LocalInfo::LocalInfo* root_local_info_{nullptr}; // set only for root_context.
   PluginHandleSharedPtr plugin_handle_{nullptr};
+#if defined(HIGRESS)
+  bool active_stream_count_recorded_ = false;
+#endif
 
   uint32_t next_http_call_token_ = 1;
   uint32_t next_grpc_token_ = 1; // Odd tokens are for Calls even for Streams.

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -3,6 +3,9 @@
 #include <memory>
 
 #include "envoy/server/lifecycle_notifier.h"
+#ifdef HIGRESS
+#include "envoy/stats/histogram.h"
+#endif
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -32,24 +35,35 @@ struct CreateWasmStats {
 };
 
 #ifdef HIGRESS
-#define LIFECYCLE_STATS(COUNTER, GAUGE, PLUGIN_COUNTER, PLUGIN_GAUGE)                              \
+#define LIFECYCLE_STATS(COUNTER, GAUGE, PLUGIN_COUNTER, PLUGIN_GAUGE, PLUGIN_HISTOGRAM)            \
   COUNTER(created)                                                                                 \
   GAUGE(active, NeverImport)                                                                       \
   PLUGIN_COUNTER(recover_total)                                                                    \
   PLUGIN_COUNTER(rebuild_total)                                                                    \
+  PLUGIN_COUNTER(rebuild_memory_total)                                                             \
+  PLUGIN_COUNTER(rebuild_explicit_total)                                                           \
   PLUGIN_COUNTER(crash_total)                                                                      \
   PLUGIN_COUNTER(recover_error)                                                                    \
-  PLUGIN_GAUGE(crash, NeverImport)
+  PLUGIN_GAUGE(crash, NeverImport)                                                                 \
+  PLUGIN_HISTOGRAM(reclaim_latency, Milliseconds)
 #else
 #define LIFECYCLE_STATS(COUNTER, GAUGE)                                                            \
   COUNTER(created)                                                                                 \
   GAUGE(active, NeverImport)
 #endif
 
+#ifdef HIGRESS
+#define RUNTIME_STATS(PLUGIN_GAUGE) PLUGIN_GAUGE(memory_size, NeverImport)
+
+struct RuntimeStats {
+  RUNTIME_STATS(GENERATE_GAUGE_STRUCT)
+};
+#endif
+
 struct LifecycleStats {
 #ifdef HIGRESS
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_COUNTER_STRUCT,
-                  GENERATE_GAUGE_STRUCT)
+                  GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 #else
   LIFECYCLE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 #endif
@@ -116,8 +130,9 @@ public:
             POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")),
             POOL_COUNTER_PREFIX(*scope,
                                 absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")),
-            POOL_GAUGE_PREFIX(*scope,
-                              absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")))}){};
+            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")),
+            POOL_HISTOGRAM_PREFIX(
+                *scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")))}){};
 #else
   LifecycleStatsHandler(const Stats::ScopeSharedPtr& scope, std::string runtime)
       : lifecycle_stats_(LifecycleStats{
@@ -139,6 +154,27 @@ protected:
   bool is_crashed_ = false;
 #endif
 };
+
+#ifdef HIGRESS
+class RuntimeStatsHandler {
+public:
+  RuntimeStatsHandler(const Stats::ScopeSharedPtr& scope, const std::string& runtime,
+                      const std::string& plugin_name, const std::string& thread_name)
+      : runtime(runtime), plugin_name(plugin_name),
+        runtime_stats_(RuntimeStats{RUNTIME_STATS(
+            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".",
+                                                   thread_name, ".")))}) {}
+
+  ~RuntimeStatsHandler() = default;
+
+  std::string runtime;
+  std::string plugin_name;
+  void updateMemorySize(uint64_t memory_size) { runtime_stats_.memory_size_.set(memory_size); }
+
+protected:
+  RuntimeStats runtime_stats_;
+};
+#endif
 
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <string>
+#include <vector>
 
 #include "envoy/event/deferred_deletable.h"
 
@@ -10,6 +12,7 @@
 #include "source/extensions/common/wasm/plugin.h"
 #include "source/extensions/common/wasm/stats_handler.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
 
 using proxy_wasm::FailState;
@@ -86,6 +89,69 @@ WasmEvent failStateToWasmEvent(FailState state) {
 }
 
 const int MIN_RECOVER_INTERVAL_SECONDS = 1;
+constexpr uint64_t DefaultReclaimMemoryThresholdBytes = 800ULL * 1024 * 1024;
+constexpr absl::string_view ReclaimMemoryThresholdRuntimeKey =
+    "envoy.wasm.reclaim.memory_threshold_bytes";
+
+MonotonicTime effectiveMonotonicTime(Event::Dispatcher& dispatcher) {
+  return dispatcher.timeSource().monotonicTime() + cache_time_offset_for_testing;
+}
+
+struct RebuildGuardEntry {
+  MonotonicTime last_recover_time;
+  std::weak_ptr<WasmHandle> current_wasm_handle;
+  std::vector<std::weak_ptr<WasmHandle>> old_wasm_handles;
+
+  void pruneExpired(const WasmHandleSharedPtr& current_wasm_handle = nullptr) {
+    old_wasm_handles.erase(
+        std::remove_if(old_wasm_handles.begin(), old_wasm_handles.end(),
+                       [&current_wasm_handle](const std::weak_ptr<WasmHandle>& old_wasm_handle) {
+                         auto locked = old_wasm_handle.lock();
+                         return locked == nullptr || (current_wasm_handle != nullptr &&
+                                                      locked.get() == current_wasm_handle.get());
+                       }),
+        old_wasm_handles.end());
+  }
+
+  bool hasLiveOldGeneration(const WasmHandleSharedPtr& current_wasm_handle) {
+    pruneExpired(current_wasm_handle);
+    return !old_wasm_handles.empty();
+  }
+
+  void trackCurrentGeneration(const WasmHandleSharedPtr& wasm_handle) {
+    current_wasm_handle = wasm_handle;
+  }
+
+  void trackOldGeneration(const WasmHandleSharedPtr& old_wasm_handle) {
+    if (old_wasm_handle == nullptr) {
+      return;
+    }
+    pruneExpired();
+    old_wasm_handles.push_back(old_wasm_handle);
+  }
+
+  bool canRetire() {
+    pruneExpired();
+    return current_wasm_handle.expired() && old_wasm_handles.empty();
+  }
+};
+
+thread_local absl::flat_hash_map<std::string, RebuildGuardEntry> rebuild_guard_registry;
+
+void sweepRebuildGuardRegistry(const std::string& active_vm_key) {
+  for (auto it = rebuild_guard_registry.begin(); it != rebuild_guard_registry.end();) {
+    if (it->first == active_vm_key) {
+      ++it;
+      continue;
+    }
+    if (it->second.canRetire()) {
+      auto erase_it = it++;
+      rebuild_guard_registry.erase(erase_it);
+    } else {
+      ++it;
+    }
+  }
+}
 #endif
 
 } // namespace
@@ -101,8 +167,52 @@ void Wasm::initializeLifecycle(Server::ServerLifecycleNotifier& lifecycle_notifi
                                       });
 }
 
+#ifdef HIGRESS
+void Wasm::initializeRuntimeStatsTimer() {
+  runtime_stats_timer_ = dispatcher_.createTimer(
+      [weak = std::weak_ptr<Wasm>(std::static_pointer_cast<Wasm>(shared_from_this()))]() {
+        auto shared = weak.lock();
+        if (shared) {
+          shared->runtime_stats_handler_.updateMemorySize(shared->wasm_vm()->getMemorySize());
+          shared->runtime_stats_timer_->enableTimer(
+              std::chrono::milliseconds(Wasm::kRuntimeStatsInterval));
+        }
+      });
+  runtime_stats_timer_->enableTimer(std::chrono::milliseconds(Wasm::kRuntimeStatsInterval));
+}
+
+uint64_t Wasm::reclaimMemoryThreshold() const {
+  if (runtime_loader_ == nullptr) {
+    return DefaultReclaimMemoryThresholdBytes;
+  }
+  const uint64_t threshold = runtime_loader_->snapshot().getInteger(
+      ReclaimMemoryThresholdRuntimeKey, DefaultReclaimMemoryThresholdBytes);
+  return threshold == 0 ? DefaultReclaimMemoryThresholdBytes : threshold;
+}
+
+void Wasm::markReclaimEligible() {
+  if (!reclaim_eligible_since_.has_value()) {
+    reclaim_eligible_since_ = effectiveMonotonicTime(dispatcher_);
+  }
+}
+
+void Wasm::recordReclaimLatency(MonotonicTime now) {
+  if (!reclaim_eligible_since_.has_value()) {
+    return;
+  }
+  const auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - reclaim_eligible_since_.value());
+  lifecycleStats().reclaim_latency_.recordValue(elapsed.count() < 0 ? 0 : elapsed.count());
+}
+#endif
+
 Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeSharedPtr& scope,
-           Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher)
+           Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher
+#ifdef HIGRESS
+           ,
+           Runtime::Loader* runtime
+#endif
+           )
     : WasmBase(
           createWasmVm(config.config().vm_config().runtime()), config.config().vm_config().vm_id(),
           MessageUtil::anyToBytes(config.config().vm_config().configuration()),
@@ -112,17 +222,25 @@ Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeShare
       cluster_manager_(cluster_manager), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
 #ifdef HIGRESS
+      runtime_stats_handler_(RuntimeStatsHandler(scope, config.config().vm_config().runtime(),
+                                                 config.config().name(), dispatcher.name())),
+      runtime_loader_(runtime),
       lifecycle_stats_handler_(LifecycleStatsHandler(scope, config.config().vm_config().runtime(),
                                                      config.config().name())) {
 #else
       lifecycle_stats_handler_(
-          LifecycleStatsHandler(scope, config.config().vm_config().runtime()) {
+          LifecycleStatsHandler(scope, config.config().vm_config().runtime())) {
 #endif
   lifecycle_stats_handler_.onEvent(WasmEvent::VmCreated);
   ENVOY_LOG(debug, "Base Wasm created {} now active", lifecycle_stats_handler_.getActiveVmCount());
 }
 
-Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
+Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher
+#ifdef HIGRESS
+           ,
+           Runtime::Loader* runtime
+#endif
+           )
     : WasmBase(base_wasm_handle,
                [&base_wasm_handle]() {
                  return createWasmVm(absl::StrCat(
@@ -134,6 +252,13 @@ Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
       custom_stat_namespace_(stat_name_pool_.add(CustomStatNamespace)),
       cluster_manager_(getWasm(base_wasm_handle)->clusterManager()), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
+#ifdef HIGRESS
+      runtime_stats_handler_(RuntimeStatsHandler(
+          getWasm(base_wasm_handle)->scope_,
+          getWasm(base_wasm_handle)->runtime_stats_handler_.runtime,
+          getWasm(base_wasm_handle)->runtime_stats_handler_.plugin_name, dispatcher.name())),
+      runtime_loader_(runtime != nullptr ? runtime : getWasm(base_wasm_handle)->runtime_loader_),
+#endif
       lifecycle_stats_handler_(getWasm(base_wasm_handle)->lifecycle_stats_handler_) {
   lifecycle_stats_handler_.onEvent(WasmEvent::VmCreated);
 #ifdef HIGRESS
@@ -188,6 +313,11 @@ void Wasm::tickHandler(uint32_t root_context_id) {
 
 Wasm::~Wasm() {
   lifecycle_stats_handler_.onEvent(WasmEvent::VmShutDown);
+#ifdef HIGRESS
+  if (runtime_stats_timer_) {
+    runtime_stats_timer_->disableTimer();
+  }
+#endif
   ENVOY_LOG(debug, "~Wasm {} remaining active", lifecycle_stats_handler_.getActiveVmCount());
   if (server_shutdown_post_cb_) {
     dispatcher_.post(std::move(server_shutdown_post_cb_));
@@ -195,42 +325,162 @@ Wasm::~Wasm() {
 }
 
 #if defined(HIGRESS)
-bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery) {
+PluginHandleSharedPtrThreadLocal::PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle,
+                                                                   WasmHandleSharedPtr base_wasm,
+                                                                   bool enable_reclaim_timer)
+    : plugin_(handle != nullptr ? std::static_pointer_cast<Plugin>(handle->plugin()) : nullptr),
+      base_wasm_(base_wasm), reclaim_timer_enabled_(enable_reclaim_timer), handle_(handle) {
+  initializeReclaimTimer();
+}
+
+PluginHandleSharedPtrThreadLocal::~PluginHandleSharedPtrThreadLocal() {
+  if (reclaim_timer_) {
+    reclaim_timer_->disableTimer();
+  }
+}
+
+void PluginHandleSharedPtrThreadLocal::initializeReclaimTimer() {
+  if (!reclaim_timer_enabled_) {
+    return;
+  }
+  if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
+      handle_->wasmHandle()->wasm() == nullptr) {
+    return;
+  }
+  reclaim_timer_ =
+      handle_->wasmHandle()->wasm()->dispatcher().createTimer([this]() { onReclaimTimer(); });
+  reclaim_timer_->enableTimer(kReclaimTimerInterval);
+}
+
+void PluginHandleSharedPtrThreadLocal::runReclaimTimerForTesting() { onReclaimTimer(); }
+
+void PluginHandleSharedPtrThreadLocal::onReclaimTimer() {
+  auto rearm = [this]() {
+    if (reclaim_timer_) {
+      reclaim_timer_->enableTimer(kReclaimTimerInterval);
+    }
+  };
+
+  if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
+      handle_->wasmHandle()->wasm() == nullptr) {
+    rearm();
+    return;
+  }
+
+  auto wasm = handle_->wasmHandle()->wasm();
+  const uint64_t memory_size = wasm->wasm_vm() != nullptr ? wasm->wasm_vm()->getMemorySize() : 0;
+  const bool memory_triggered = memory_size > wasm->reclaimMemoryThreshold();
+  const bool explicit_triggered = wasm->shouldRebuild();
+  if (!memory_triggered && !explicit_triggered) {
+    rearm();
+    return;
+  }
+
+  RebuildSource source = RebuildSource::Explicit;
+  if (memory_triggered) {
+    source = RebuildSource::Memory;
+    wasm->markReclaimEligible();
+    wasm->setShouldRebuild(true);
+  } else {
+    wasm->markReclaimEligible();
+  }
+
+  rebuild(false, source);
+  if (memory_triggered) {
+    wasm->setShouldRebuild(false);
+  }
+  rearm();
+}
+
+bool PluginHandleSharedPtrThreadLocal::syncHandleToCurrentGeneration(const std::string& vm_key) {
+  auto current_base = proxy_wasm::getThreadLocalWasm(vm_key);
+  if (current_base == nullptr) {
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: no current generation for vm_key");
+    return false;
+  }
+  auto current_wasm_handle = std::static_pointer_cast<WasmHandle>(current_base);
+  if (handle_ != nullptr && handle_->wasmHandle() != nullptr &&
+      handle_->wasmHandle().get() == current_wasm_handle.get()) {
+    return true;
+  }
+  if (base_wasm_ != nullptr && plugin_ != nullptr) {
+    auto synced_handle = getOrCreateThreadLocalPlugin(base_wasm_, plugin_,
+                                                      current_wasm_handle->wasm()->dispatcher());
+    if (synced_handle != nullptr && synced_handle->wasmHandle() != nullptr &&
+        synced_handle->wasmHandle().get() == current_wasm_handle.get()) {
+      handle_ = synced_handle;
+      ENVOY_LOG(info, "wasm vm proactive rebuild skipped: stale wrapper synchronized to current "
+                      "generation");
+      return false;
+    }
+  }
+  ENVOY_LOG(info, "wasm vm proactive rebuild skipped: stale wrapper has no current plugin handle");
+  return false;
+}
+
+bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery, RebuildSource source) {
   if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
       handle_->wasmHandle()->wasm() == nullptr) {
     ENVOY_LOG(warn, "wasm has not been initialized");
     return false;
   }
-  auto& dispatcher = handle_->wasmHandle()->wasm()->dispatcher();
-  auto now = dispatcher.timeSource().monotonicTime() + cache_time_offset_for_testing;
-  if (now - last_recover_time_ < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
-    ENVOY_LOG(info, "rebuild interval has not been reached");
+  auto current_wasm_handle = handle_->wasmHandle();
+  auto current_wasm = current_wasm_handle->wasm();
+  const std::string vm_key(current_wasm->vm_key());
+  if (!is_fail_recovery && !syncHandleToCurrentGeneration(vm_key)) {
     return false;
   }
-  // Check if old handle is still alive (still being referenced by old requests)
-  // If it's still alive, we don't want to create another VM to prevent memory accumulation
-  // For fail recovery scenarios, skip this check to ensure recovery can proceed
-  if (!is_fail_recovery && !old_handle_.expired()) {
-    ENVOY_LOG(info, "old wasm vm handle is still in use, skipping rebuild to prevent VM accumulation");
+  current_wasm_handle = handle_->wasmHandle();
+  current_wasm = current_wasm_handle->wasm();
+  sweepRebuildGuardRegistry(vm_key);
+  auto& guard = rebuild_guard_registry[vm_key];
+  guard.trackCurrentGeneration(current_wasm_handle);
+  auto& dispatcher = current_wasm->dispatcher();
+  auto now = effectiveMonotonicTime(dispatcher);
+  if (now - guard.last_recover_time < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
+    ENVOY_LOG(info, "wasm vm rebuild skipped: recover interval has not been reached");
+    return false;
+  }
+  if (!is_fail_recovery && guard.hasLiveOldGeneration(current_wasm_handle)) {
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: live generation cap reached");
+    return false;
+  }
+  const auto active_stream_count = current_wasm->activeStreamCount();
+  if (!is_fail_recovery && active_stream_count > 0) {
+    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: current generation has {} active streams",
+              active_stream_count);
     return false;
   }
   // Even if rebuild fails, it will be retried after the interval
-  last_recover_time_ = now;
+  guard.last_recover_time = now;
   std::shared_ptr<PluginHandleBase> new_handle;
-  if (handle_->rebuild(new_handle)) {
-    // Store weak_ptr to current handle before replacing it
-    old_handle_ = handle_;
-    handle_ = std::static_pointer_cast<PluginHandle>(new_handle);
+  if (handle_->rebuild(new_handle) && new_handle != nullptr) {
+    auto new_plugin_handle = std::static_pointer_cast<PluginHandle>(new_handle);
+    auto new_wasm_handle = new_plugin_handle->wasmHandle();
+    if (new_wasm_handle != nullptr && new_wasm_handle.get() != current_wasm_handle.get()) {
+      guard.trackOldGeneration(current_wasm_handle);
+    }
+    guard.trackCurrentGeneration(new_wasm_handle);
+    handle_ = new_plugin_handle;
     // Increment appropriate metrics based on rebuild type
     if (is_fail_recovery) {
       handle_->wasmHandle()->wasm()->lifecycleStats().recover_total_.inc();
       ENVOY_LOG(info, "wasm vm recover from crash success");
     } else {
-      handle_->wasmHandle()->wasm()->lifecycleStats().rebuild_total_.inc();
+      auto& stats = handle_->wasmHandle()->wasm()->lifecycleStats();
+      stats.rebuild_total_.inc();
+      if (source == RebuildSource::Memory) {
+        stats.rebuild_memory_total_.inc();
+      } else {
+        stats.rebuild_explicit_total_.inc();
+      }
+      current_wasm->recordReclaimLatency(now);
+      current_wasm->clearReclaimEligible();
       ENVOY_LOG(info, "wasm vm rebuild success");
     }
     return true;
   }
+  ENVOY_LOG(info, "wasm vm {} execution failed", is_fail_recovery ? "recover" : "rebuild");
   return false;
 }
 #endif
@@ -329,8 +579,16 @@ void clearCodeCacheForTesting() {
     delete code_cache;
     code_cache = nullptr;
   }
+  cache_time_offset_for_testing = {};
+#if defined(HIGRESS)
+  rebuild_guard_registry.clear();
+#endif
   getCreateStatsHandler().resetStatsForTesting();
 }
+
+#if defined(HIGRESS)
+size_t rebuildGuardRegistrySizeForTesting() { return rebuild_guard_registry.size(); }
+#endif
 
 // TODO: remove this post #4160: Switch default to SimulatedTimeSystem.
 void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d) {
@@ -340,11 +598,25 @@ void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d) {
 static proxy_wasm::WasmHandleFactory
 getWasmHandleFactory(WasmConfig& wasm_config, const Stats::ScopeSharedPtr& scope, Api::Api& api,
                      Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher,
-                     Server::ServerLifecycleNotifier& lifecycle_notifier) {
-  return [&wasm_config, &scope, &api, &cluster_manager, &dispatcher,
-          &lifecycle_notifier](std::string_view vm_key) -> WasmHandleBaseSharedPtr {
+                     Server::ServerLifecycleNotifier& lifecycle_notifier
+#if defined(HIGRESS)
+                     ,
+                     Runtime::Loader* runtime
+#endif
+) {
+  return [&wasm_config, &scope, &api, &cluster_manager, &dispatcher, &lifecycle_notifier
+#if defined(HIGRESS)
+          ,
+          runtime
+#endif
+  ](std::string_view vm_key) -> WasmHandleBaseSharedPtr {
     auto wasm = std::make_shared<Wasm>(wasm_config, toAbslStringView(vm_key), scope, api,
-                                       cluster_manager, dispatcher);
+                                       cluster_manager, dispatcher
+#if defined(HIGRESS)
+                                       ,
+                                       runtime
+#endif
+    );
     wasm->initializeLifecycle(lifecycle_notifier);
     return std::static_pointer_cast<WasmHandleBase>(std::make_shared<WasmHandle>(std::move(wasm)));
   };
@@ -357,6 +629,9 @@ getWasmHandleCloneFactory(Event::Dispatcher& dispatcher,
              WasmHandleBaseSharedPtr base_wasm) -> std::shared_ptr<WasmHandleBase> {
     auto wasm = std::make_shared<Wasm>(std::static_pointer_cast<WasmHandle>(base_wasm), dispatcher);
     wasm->setCreateContextForTesting(nullptr, create_root_context_for_testing);
+#ifdef HIGRESS
+    wasm->initializeRuntimeStatsTimer();
+#endif
     return std::static_pointer_cast<WasmHandleBase>(std::make_shared<WasmHandle>(std::move(wasm)));
   };
 }
@@ -404,7 +679,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
                 Event::Dispatcher& dispatcher, Api::Api& api,
                 Server::ServerLifecycleNotifier& lifecycle_notifier,
                 Config::DataSource::RemoteAsyncDataProviderPtr& remote_data_provider,
-                CreateWasmCallback&& cb, CreateContextFn create_root_context_for_testing) {
+                CreateWasmCallback&& cb, CreateContextFn create_root_context_for_testing
+#if defined(HIGRESS)
+                ,
+                Runtime::Loader* runtime
+#endif
+) {
   auto& stats_handler = getCreateStatsHandler();
   std::string source, code;
   auto config = plugin->wasmConfig();
@@ -471,7 +751,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
 
   auto vm_key = proxy_wasm::makeVmKey(vm_config.vm_id(),
                                       MessageUtil::anyToBytes(vm_config.configuration()), code);
-  auto complete_cb = [cb, vm_key, plugin, scope, &api, &cluster_manager, &dispatcher,
+  auto complete_cb = [cb, vm_key, plugin, scope, &api, &cluster_manager, &dispatcher
+#if defined(HIGRESS)
+                      ,
+                      runtime
+#endif
+                      ,
                       &lifecycle_notifier, create_root_context_for_testing,
                       &stats_handler](std::string code) -> bool {
     if (code.empty()) {
@@ -482,7 +767,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
     auto config = plugin->wasmConfig();
     auto wasm = proxy_wasm::createWasm(
         vm_key, code, plugin,
-        getWasmHandleFactory(config, scope, api, cluster_manager, dispatcher, lifecycle_notifier),
+        getWasmHandleFactory(config, scope, api, cluster_manager, dispatcher, lifecycle_notifier
+#if defined(HIGRESS)
+                             ,
+                             runtime
+#endif
+                             ),
         getWasmHandleCloneFactory(dispatcher, create_root_context_for_testing),
         config.config().vm_config().allow_precompiled());
     Stats::ScopeSharedPtr create_wasm_stats_scope = stats_handler.lockAndCreateStats(scope);

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -8,6 +8,9 @@
 #include "envoy/common/exception.h"
 #include "envoy/extensions/wasm/v3/wasm.pb.validate.h"
 #include "envoy/http/filter.h"
+#if defined(HIGRESS)
+#include "envoy/runtime/runtime.h"
+#endif
 #include "envoy/server/lifecycle_notifier.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
@@ -27,6 +30,10 @@
 #include "include/proxy-wasm/exports.h"
 #include "include/proxy-wasm/wasm.h"
 
+#if defined(HIGRESS)
+#include "absl/types/optional.h"
+#endif
+
 namespace Envoy {
 namespace Extensions {
 namespace Common {
@@ -41,8 +48,18 @@ class WasmHandle;
 class Wasm : public WasmBase, Logger::Loggable<Logger::Id::wasm> {
 public:
   Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeSharedPtr& scope,
-       Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher);
-  Wasm(std::shared_ptr<WasmHandle> other, Event::Dispatcher& dispatcher);
+       Api::Api& api, Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher
+#if defined(HIGRESS)
+       ,
+       Runtime::Loader* runtime = nullptr
+#endif
+  );
+  Wasm(std::shared_ptr<WasmHandle> other, Event::Dispatcher& dispatcher
+#if defined(HIGRESS)
+       ,
+       Runtime::Loader* runtime = nullptr
+#endif
+  );
   ~Wasm() override;
 
   Upstream::ClusterManager& clusterManager() const { return cluster_manager_; }
@@ -76,6 +93,17 @@ public:
   virtual std::string buildVersion() { return BUILD_VERSION_NUMBER; }
 
   void initializeLifecycle(Server::ServerLifecycleNotifier& lifecycle_notifier);
+
+#if defined(HIGRESS)
+  void initializeRuntimeStatsTimer();
+  uint64_t reclaimMemoryThreshold() const;
+  void markReclaimEligible();
+  void clearReclaimEligible() { reclaim_eligible_since_.reset(); }
+  const absl::optional<MonotonicTime>& reclaimEligibleSinceForTesting() const {
+    return reclaim_eligible_since_;
+  }
+#endif
+
   uint32_t nextDnsToken() {
     do {
       dns_token_++;
@@ -92,6 +120,17 @@ public:
 
 #if defined(HIGRESS)
   LifecycleStats& lifecycleStats() { return lifecycle_stats_handler_.stats(); }
+  void recordReclaimLatency(MonotonicTime now);
+  void incrementActiveStreamCount() { ++active_stream_count_; }
+  void decrementActiveStreamCount() {
+    ASSERT(active_stream_count_ > 0);
+    if (active_stream_count_ == 0) {
+      ENVOY_LOG(error, "wasm active stream count underflow");
+      return;
+    }
+    --active_stream_count_;
+  }
+  uint64_t activeStreamCount() const { return active_stream_count_; }
 #endif
 
 protected:
@@ -111,6 +150,16 @@ protected:
   Event::PostCb server_shutdown_post_cb_;
   absl::flat_hash_map<uint32_t, Event::TimerPtr> timer_; // per root_id.
   TimeSource& time_source_;
+
+#if defined(HIGRESS)
+  // Runtime stats
+  RuntimeStatsHandler runtime_stats_handler_;
+  Event::TimerPtr runtime_stats_timer_;
+  static constexpr std::chrono::milliseconds kRuntimeStatsInterval{1000};
+  uint64_t active_stream_count_ = 0;
+  Runtime::Loader* runtime_loader_;
+  absl::optional<MonotonicTime> reclaim_eligible_since_;
+#endif
 
   // Lifecycle stats
   LifecycleStatsHandler lifecycle_stats_handler_;
@@ -158,11 +207,17 @@ private:
 using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;
 
 #if defined(HIGRESS)
+enum class RebuildSource { Explicit, Memory };
+
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject,
                                          public Logger::Loggable<Logger::Id::wasm> {
 public:
-  PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle) : handle_(handle){};
-  bool rebuild(bool is_fail_recovery = false);
+  PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle,
+                                   WasmHandleSharedPtr base_wasm = nullptr,
+                                   bool enable_reclaim_timer = false);
+  ~PluginHandleSharedPtrThreadLocal() override;
+  bool rebuild(bool is_fail_recovery = false, RebuildSource source = RebuildSource::Explicit);
+  void runReclaimTimerForTesting();
 #else
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject {
 public:
@@ -171,11 +226,17 @@ public:
   PluginHandleSharedPtr& handle() { return handle_; }
 
 private:
-  PluginHandleSharedPtr handle_;
 #if defined(HIGRESS)
-  MonotonicTime last_recover_time_;
-  std::weak_ptr<PluginHandle> old_handle_;
+  void initializeReclaimTimer();
+  void onReclaimTimer();
+  bool syncHandleToCurrentGeneration(const std::string& vm_key);
+  PluginSharedPtr plugin_;
+  WasmHandleSharedPtr base_wasm_;
+  Event::TimerPtr reclaim_timer_;
+  bool reclaim_timer_enabled_;
+  static constexpr std::chrono::milliseconds kReclaimTimerInterval{1000};
 #endif
+  PluginHandleSharedPtr handle_;
 };
 
 using CreateWasmCallback = std::function<void(WasmHandleSharedPtr)>;
@@ -190,7 +251,12 @@ bool createWasm(const PluginSharedPtr& plugin, const Stats::ScopeSharedPtr& scop
                 Envoy::Server::ServerLifecycleNotifier& lifecycle_notifier,
                 Config::DataSource::RemoteAsyncDataProviderPtr& remote_data_provider,
                 CreateWasmCallback&& callback,
-                CreateContextFn create_root_context_for_testing = nullptr);
+                CreateContextFn create_root_context_for_testing = nullptr
+#if defined(HIGRESS)
+                ,
+                Runtime::Loader* runtime = nullptr
+#endif
+);
 
 PluginHandleSharedPtr
 getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginSharedPtr& plugin,
@@ -199,6 +265,9 @@ getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginS
 
 void clearCodeCacheForTesting();
 void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d);
+#if defined(HIGRESS)
+size_t rebuildGuardRegistrySizeForTesting();
+#endif
 WasmEvent toWasmEvent(const std::shared_ptr<WasmHandleBase>& wasm);
 
 } // namespace Wasm

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -13,18 +13,35 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
       config.config(), context.direction(), context.localInfo(), &context.listenerMetadata());
 
   auto callback = [plugin, this](const Common::Wasm::WasmHandleSharedPtr& base_wasm) {
+#if defined(HIGRESS)
     base_wasm_handle_ = base_wasm;
+#endif
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot_->set([base_wasm, plugin](Event::Dispatcher& dispatcher) {
+#if defined(HIGRESS)
+      return std::make_shared<PluginHandleSharedPtrThreadLocal>(
+          Common::Wasm::getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher), base_wasm,
+          true);
+#else
       return std::make_shared<PluginHandleSharedPtrThreadLocal>(
           Common::Wasm::getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher));
+#endif
     });
   };
 
-  if (!Common::Wasm::createWasm(plugin, context.scope().createScope(""), context.clusterManager(),
-                                context.initManager(), context.mainThreadDispatcher(),
-                                context.api(), context.lifecycleNotifier(), remote_data_provider_,
-                                std::move(callback))) {
+  bool created = false;
+#if defined(HIGRESS)
+  created = Common::Wasm::createWasm(
+      plugin, context.scope().createScope(""), context.clusterManager(), context.initManager(),
+      context.mainThreadDispatcher(), context.api(), context.lifecycleNotifier(),
+      remote_data_provider_, std::move(callback), nullptr, &context.runtime());
+#else
+  created = Common::Wasm::createWasm(
+      plugin, context.scope().createScope(""), context.clusterManager(), context.initManager(),
+      context.mainThreadDispatcher(), context.api(), context.lifecycleNotifier(),
+      remote_data_provider_, std::move(callback));
+#endif
+  if (!created) {
     throw Common::Wasm::WasmException(
         fmt::format("Unable to create Wasm HTTP filter {}", plugin->name_));
   }

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -56,17 +56,6 @@ public:
         ENVOY_LOG(info, "wasm vm recover failed");
         failed = true;
       }
-    } else if (wasm->shouldRebuild()) {
-      ENVOY_LOG(info, "wasm vm requested rebuild, try to rebuild");
-      if (opt_ref->rebuild(false)) {
-        ENVOY_LOG(info, "wasm vm rebuild success");
-        wasm = opt_ref->handle()->wasmHandle()->wasm().get();
-        handle = opt_ref->handle();
-        // Reset rebuild state
-        wasm->setShouldRebuild(false);
-      } else {
-        ENVOY_LOG(info, "wasm vm rebuild failed, still using the stale one");
-      }
     }
     if (failed) {
       if (handle->plugin()->fail_open_) {
@@ -92,7 +81,9 @@ public:
 private:
   ThreadLocal::TypedSlotPtr<PluginHandleSharedPtrThreadLocal> tls_slot_;
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;
+#if defined(HIGRESS)
   Envoy::Extensions::Common::Wasm::WasmHandleSharedPtr base_wasm_handle_;
+#endif
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "envoy/grpc/async_client.h"
 #include "envoy/redis/async_client.h"
 
@@ -35,7 +37,12 @@ namespace Wasm {
 
 using Envoy::Extensions::Common::Wasm::CreateContextFn;
 using Envoy::Extensions::Common::Wasm::Plugin;
+using Envoy::Extensions::Common::Wasm::PluginHandle;
 using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtr;
+using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtrThreadLocal;
+#if defined(HIGRESS)
+using Envoy::Extensions::Common::Wasm::RebuildSource;
+#endif
 using Envoy::Extensions::Common::Wasm::Wasm;
 using Envoy::Extensions::Common::Wasm::WasmHandleSharedPtr;
 using proxy_wasm::ContextBase;
@@ -97,10 +104,67 @@ public:
   TestRoot& rootContext() { return *static_cast<TestRoot*>(root_context_); }
   TestFilter& filter() { return *static_cast<TestFilter*>(context_.get()); }
 
+#if defined(HIGRESS)
+  void advanceRebuildInterval() {
+    rebuild_time_offset_ += std::chrono::seconds(2);
+    Envoy::Extensions::Common::Wasm::setTimeOffsetForCodeCacheForTesting(rebuild_time_offset_);
+  }
+
+  bool rebuildThroughThreadLocal(PluginHandleSharedPtrThreadLocal& thread_local_handle,
+                                 bool is_fail_recovery = false,
+                                 RebuildSource source = RebuildSource::Explicit) {
+    if (!is_fail_recovery && thread_local_handle.handle() != nullptr &&
+        thread_local_handle.handle()->wasmHandle() != nullptr &&
+        thread_local_handle.handle()->wasmHandle()->wasm() != nullptr) {
+      thread_local_handle.handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+    }
+    const bool rebuilt = thread_local_handle.rebuild(is_fail_recovery, source);
+    if (rebuilt) {
+      plugin_handle_ = thread_local_handle.handle();
+      wasm_ = plugin_handle_->wasmHandle();
+      if (!is_fail_recovery && wasm_ != nullptr && wasm_->wasm() != nullptr) {
+        wasm_->wasm()->setShouldRebuild(false);
+      }
+    }
+    return rebuilt;
+  }
+
+  std::unique_ptr<PluginHandleSharedPtrThreadLocal>
+  makeThreadLocalHandle(bool enable_reclaim_timer = false) {
+    return std::make_unique<PluginHandleSharedPtrThreadLocal>(plugin_handle_, base_wasm_,
+                                                              enable_reclaim_timer);
+  }
+
+  void adoptThreadLocalHandle(PluginHandleSharedPtrThreadLocal& thread_local_handle) {
+    plugin_handle_ = thread_local_handle.handle();
+    wasm_ = plugin_handle_->wasmHandle();
+  }
+
+  std::unique_ptr<TestFilter> makeStreamContext(const PluginHandleSharedPtr& plugin_handle) {
+    auto* wasm = plugin_handle != nullptr && plugin_handle->wasmHandle() != nullptr
+                     ? plugin_handle->wasmHandle()->wasm().get()
+                     : nullptr;
+    const uint32_t root_context_id = wasm != nullptr ? plugin_handle->rootContextId() : 0;
+    return std::make_unique<TestFilter>(wasm, root_context_id, plugin_handle);
+  }
+
+  void releaseWasmState() {
+    context_.reset();
+    plugin_handle_.reset();
+    wasm_.reset();
+    base_wasm_.reset();
+    plugin_.reset();
+    root_context_ = nullptr;
+  }
+#endif
+
 protected:
   NiceMock<Grpc::MockAsyncStream> async_stream_;
   Grpc::MockAsyncClientManager async_client_manager_;
   NiceMock<Tracing::MockSpan> mock_span_;
+#if defined(HIGRESS)
+  std::chrono::seconds rebuild_time_offset_{0};
+#endif
 };
 
 INSTANTIATE_TEST_SUITE_P(RuntimesAndLanguages, WasmHttpFilterTest,
@@ -2004,6 +2068,479 @@ TEST_P(WasmHttpFilterTest, GetVMMemorySize) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   filter().onDestroy();
 }
+
+TEST_P(WasmHttpFilterTest, ActiveStreamCounterTracksStreamContextLifetime) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  {
+    auto stream_context = makeStreamContext(plugin_handle_);
+    EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+    stream_context->onDestroy();
+    EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+  }
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  {
+    auto stream_context = makeStreamContext(plugin_handle_);
+    EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+  }
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildNoOldGenerationStillSucceeds) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& recover_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.recover_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, recover_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentActive) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+  PluginHandleSharedPtr current_generation_handle = thread_local_handle.handle();
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(current_generation_handle.get(), thread_local_handle.handle().get());
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenOldGenerationLiveAndCurrentIdle) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  old_generation_handle.reset();
+
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(2U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenCurrentGenerationActiveWithoutOld) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, RebuildGuardRegistryRetiresStaleVmKeys) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  {
+    PluginHandleSharedPtrThreadLocal first_thread_local_handle(plugin_handle_);
+    advanceRebuildInterval();
+    ASSERT_TRUE(rebuildThroughThreadLocal(first_thread_local_handle));
+    EXPECT_EQ(1U, Envoy::Extensions::Common::Wasm::rebuildGuardRegistrySizeForTesting());
+  }
+  releaseWasmState();
+
+  setupTest("", "RebuildTestRegistryRetire");
+  PluginHandleSharedPtrThreadLocal second_thread_local_handle(plugin_handle_);
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(second_thread_local_handle));
+  EXPECT_EQ(1U, Envoy::Extensions::Common::Wasm::rebuildGuardRegistrySizeForTesting());
+}
+
+TEST_P(WasmHttpFilterTest, NewThreadLocalWrapperKeepsRebuildGuardState) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  PluginHandleSharedPtrThreadLocal new_wrapper(plugin_handle_);
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(new_wrapper));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, ActiveCounterIncludesDifferentPluginHandleOnSameGeneration) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  auto sibling_plugin_handle =
+      std::make_shared<PluginHandle>(plugin_handle_->wasmHandle(), plugin_);
+  auto sibling_stream_context = makeStreamContext(sibling_plugin_handle);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  sibling_stream_context->onDestroy();
+  EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
+}
+
+TEST_P(WasmHttpFilterTest, FailRecoveryBypassesProactiveActiveGuard) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& recover_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.recover_total");
+
+  PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  PluginHandleSharedPtr old_generation_handle = plugin_handle_;
+  ASSERT_NE(nullptr, old_generation_handle);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, recover_total.value());
+
+  auto current_stream_context = makeStreamContext(plugin_handle_);
+  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
+
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle, true));
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(1U, recover_total.value());
+
+  current_stream_context->onDestroy();
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerRebuildsIdleVmWhenShouldRebuildIsSet) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& rebuild_explicit_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_explicit_total");
+  auto& rebuild_memory_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto old_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  old_wasm->setShouldRebuild(true);
+  old_wasm->markReclaimEligible();
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(1U, rebuild_explicit_total.value());
+  EXPECT_EQ(0U, rebuild_memory_total.value());
+  EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerUsesMemoryThresholdSourceAndRuntimeOverride) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+  auto& rebuild_explicit_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_explicit_total");
+  auto& rebuild_memory_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("envoy.wasm.reclaim.memory_threshold_bytes", 800ULL * 1024 * 1024))
+      .WillRepeatedly(Return(1));
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto old_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  EXPECT_FALSE(old_wasm->shouldRebuild());
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_EQ(0U, rebuild_explicit_total.value());
+  EXPECT_EQ(1U, rebuild_memory_total.value());
+  EXPECT_FALSE(old_wasm->shouldRebuild());
+  EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimMemoryThresholdFallsBackWhenRuntimeValueIsZero) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("envoy.wasm.reclaim.memory_threshold_bytes", 800ULL * 1024 * 1024))
+      .WillOnce(Return(0));
+  EXPECT_EQ(800ULL * 1024 * 1024, wasm_->wasm()->reclaimMemoryThreshold());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerSkipKeepsEligibleSinceUntilSuccessfulReclaim) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  auto stream_context = makeStreamContext(plugin_handle_);
+  auto wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  wasm->setShouldRebuild(true);
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+
+  EXPECT_EQ(0U, rebuild_total.value());
+  EXPECT_TRUE(wasm->reclaimEligibleSinceForTesting().has_value());
+
+  stream_context->onDestroy();
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_FALSE(wasm->reclaimEligibleSinceForTesting().has_value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerStillHonorsRecoverInterval) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto thread_local_handle = makeThreadLocalHandle(true);
+  thread_local_handle->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  thread_local_handle->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  thread_local_handle->runReclaimTimerForTesting();
+  EXPECT_EQ(1U, rebuild_total.value());
+}
+
+TEST_P(WasmHttpFilterTest, ReclaimTimerDoesNotCrashForEmptyHandle) {
+  PluginHandleSharedPtrThreadLocal thread_local_handle(nullptr, nullptr, true);
+  thread_local_handle.runReclaimTimerForTesting();
+}
+
+TEST_P(WasmHttpFilterTest, StaleWrapperSynchronizesToHostCurrentBeforeReclaim) {
+  auto runtime = std::get<0>(GetParam());
+  if (runtime == "null") {
+    return;
+  }
+  if (std::get<1>(GetParam()) != "cpp") {
+    return;
+  }
+
+  setupTest("", "RebuildTest");
+  auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
+                                                  ".plugin.plugin_name.rebuild_total");
+
+  auto wrapper_a = makeThreadLocalHandle(true);
+  auto wrapper_b = makeThreadLocalHandle(true);
+
+  advanceRebuildInterval();
+  ASSERT_TRUE(rebuildThroughThreadLocal(*wrapper_a));
+  adoptThreadLocalHandle(*wrapper_a);
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  advanceRebuildInterval();
+  wrapper_b->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  EXPECT_FALSE(wrapper_b->rebuild(false));
+  EXPECT_EQ(plugin_handle_.get(), wrapper_b->handle().get());
+  EXPECT_EQ(1U, rebuild_total.value());
+
+  advanceRebuildInterval();
+  wrapper_b->handle()->wasmHandle()->wasm()->setShouldRebuild(true);
+  EXPECT_TRUE(rebuildThroughThreadLocal(*wrapper_b));
+  adoptThreadLocalHandle(*wrapper_b);
+  EXPECT_EQ(2U, rebuild_total.value());
+}
+
 TEST_P(WasmHttpFilterTest, RecoverFromCrash) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {

--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -14,6 +14,9 @@
 #include "test/mocks/grpc/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#if defined(HIGRESS)
+#include "test/mocks/runtime/mocks.h"
+#endif
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
@@ -81,6 +84,18 @@ public:
         &listener_metadata_);
     plugin_->wasmConfig().allowedCapabilities() = allowed_capabilities_;
     // Passes ownership of root_context_.
+#if defined(HIGRESS)
+    Extensions::Common::Wasm::createWasm(
+        plugin_, scope_, cluster_manager_, init_manager_, dispatcher_, *api, lifecycle_notifier_,
+        remote_data_provider_, [this](WasmHandleSharedPtr wasm) { base_wasm_ = wasm; }, create_root,
+        &runtime_);
+    plugin_handle_ = getOrCreateThreadLocalPlugin(
+        base_wasm_, plugin_, dispatcher_,
+        [this, create_root](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) {
+          root_context_ = static_cast<Context*>(create_root(wasm, plugin));
+          return root_context_;
+        });
+#else
     Extensions::Common::Wasm::createWasm(
         plugin_, scope_, cluster_manager_, init_manager_, dispatcher_, *api, lifecycle_notifier_,
         remote_data_provider_, [this](WasmHandleSharedPtr wasm) { wasm_ = wasm; }, create_root);
@@ -90,6 +105,7 @@ public:
           root_context_ = static_cast<Context*>(create_root(wasm, plugin));
           return root_context_;
         });
+#endif
     wasm_ = plugin_handle_->wasmHandle();
   }
 
@@ -102,7 +118,13 @@ public:
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
+#if defined(HIGRESS)
+  NiceMock<Runtime::MockLoader> runtime_;
+#endif
   NiceMock<Init::MockManager> init_manager_;
+#if defined(HIGRESS)
+  WasmHandleSharedPtr base_wasm_;
+#endif
   WasmHandleSharedPtr wasm_;
   PluginSharedPtr plugin_;
   PluginHandleSharedPtr plugin_handle_;


### PR DESCRIPTION
## Summary

Port proactive idle Wasm VM reclaim support to the Higress `envoy-1.27` branch.

This PR keeps the behavior behind the open-source `HIGRESS` macro and does not include workflow/spec artifacts.

Main changes:
- add timer-driven proactive rebuild/reclaim for idle Wasm VMs
- track active stream count before reclaiming old/current generations
- maintain worker-local rebuild guard state by `vm_key`
- add reclaim/rebuild stats, memory threshold runtime override, and reclaim latency histogram
- add focused unit coverage for rebuild guard, reclaim timer, stale wrapper sync, runtime threshold, and active stream behavior

## Metrics

The new stats are available from Envoy admin stats and can be scraped from the Prometheus endpoint:

```bash
curl -s http://127.0.0.1:15000/stats/prometheus | grep 'wasm.*plugin'
```

New per-plugin counters:
- `wasm.<runtime>.plugin.<plugin_name>.rebuild_total`: total successful proactive rebuilds
- `wasm.<runtime>.plugin.<plugin_name>.rebuild_explicit_total`: successful rebuilds triggered after the plugin explicitly sets the rebuild flag
- `wasm.<runtime>.plugin.<plugin_name>.rebuild_memory_total`: successful rebuilds triggered by VM memory crossing the runtime threshold

New per-plugin histogram:
- `wasm.<runtime>.plugin.<plugin_name>.reclaim_latency`: elapsed time from becoming reclaim-eligible to successful reclaim, in milliseconds

New per-worker gauge:
- `wasm.<runtime>.plugin.<plugin_name>.<worker_name>.memory_size`: latest Wasm VM memory size reported by that worker

Example Prometheus output, after Envoy stat-name sanitization:

```prometheus
# HELP envoy_wasm_v8_plugin_my_plugin_rebuild_total Total successful proactive rebuilds.
# TYPE envoy_wasm_v8_plugin_my_plugin_rebuild_total counter
envoy_wasm_v8_plugin_my_plugin_rebuild_total{} 3

# TYPE envoy_wasm_v8_plugin_my_plugin_rebuild_explicit_total counter
envoy_wasm_v8_plugin_my_plugin_rebuild_explicit_total{} 2

# TYPE envoy_wasm_v8_plugin_my_plugin_rebuild_memory_total counter
envoy_wasm_v8_plugin_my_plugin_rebuild_memory_total{} 1

# TYPE envoy_wasm_v8_plugin_my_plugin_reclaim_latency histogram
envoy_wasm_v8_plugin_my_plugin_reclaim_latency_bucket{le="0.5"} 0
envoy_wasm_v8_plugin_my_plugin_reclaim_latency_bucket{le="1"} 1
envoy_wasm_v8_plugin_my_plugin_reclaim_latency_bucket{le="5"} 2
envoy_wasm_v8_plugin_my_plugin_reclaim_latency_count{} 3
envoy_wasm_v8_plugin_my_plugin_reclaim_latency_sum{} 37

# TYPE envoy_wasm_v8_plugin_my_plugin_worker_0_memory_size gauge
envoy_wasm_v8_plugin_my_plugin_worker_0_memory_size{} 73400320
```

To inspect only the new metrics for one plugin:

```bash
curl -s http://127.0.0.1:15000/stats/prometheus \
  | grep -E 'envoy_wasm_.*_plugin_my_plugin_.*(rebuild|reclaim_latency|memory_size)'
```

## Verification

Passed:
- `git diff --cached --check`
- no conflict markers in touched Wasm paths
- no non-public macro references left in touched Wasm paths
- no `openspec/`, `artifacts/`, `.agents/`, or `.codex/` files staged
- `bazel --bazelrc=/tmp/envoy-1.27-reclaim/.bazelrc --bazelrc=/home/zhangty/work/envoy/clang-14.bazelrc --bazelrc=/home/zhangty/work/envoy/user-1.27.bazelrc test --config=clang //test/extensions/filters/http/wasm:wasm_filter_test --test_output=errors --test_sharding_strategy=disabled --test_arg=--gtest_filter=RuntimesAndLanguages/WasmHttpFilterTest.*Reclaim*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.*Proactive*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.*ActiveStream*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.*RebuildGuard*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.NewThreadLocal*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.StaleWrapper*/v8_cpp:RuntimesAndLanguages/WasmHttpFilterTest.FailRecovery*/v8_cpp`
  - 17/17 tests passed
- `bazel --bazelrc=/tmp/envoy-1.27-reclaim/.bazelrc --bazelrc=/home/zhangty/work/envoy/clang-14.bazelrc --bazelrc=/home/zhangty/work/envoy/user-1.27.bazelrc test --config=clang //test/extensions/common/wasm:wasm_test --test_output=errors --test_arg=--gtest_filter=*v8_cpp:*null_cpp`

Not counted as passed:
- full `//test/extensions/filters/http/wasm:wasm_filter_test` compiled and linked, but the 50-shard run did not complete successfully; multiple WAMR shards timed out and Bazel was interrupted
- full `//test/extensions/common/wasm:wasm_test` ran 72/72 gtest cases successfully, then failed in heap leak checker on WAMR-path allocations
