### PR TITLE
wasm: clarify explicit rebuild source metric

### DIFF
--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -41,7 +41,7 @@ struct CreateWasmStats {
   PLUGIN_COUNTER(recover_total)                                                                    \
   PLUGIN_COUNTER(rebuild_total)                                                                    \
   PLUGIN_COUNTER(rebuild_memory_total)                                                             \
-  PLUGIN_COUNTER(rebuild_periodic_total)                                                           \
+  PLUGIN_COUNTER(rebuild_explicit_total)                                                           \
   PLUGIN_COUNTER(crash_total)                                                                      \
   PLUGIN_COUNTER(recover_error)                                                                    \
   PLUGIN_GAUGE(crash, NeverImport)                                                                 \

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -367,13 +367,13 @@ void PluginHandleSharedPtrThreadLocal::onReclaimTimer() {
   auto wasm = handle_->wasmHandle()->wasm();
   const uint64_t memory_size = wasm->wasm_vm() != nullptr ? wasm->wasm_vm()->getMemorySize() : 0;
   const bool memory_triggered = memory_size > wasm->reclaimMemoryThreshold();
-  const bool periodic_triggered = wasm->shouldRebuild();
-  if (!memory_triggered && !periodic_triggered) {
+  const bool explicit_triggered = wasm->shouldRebuild();
+  if (!memory_triggered && !explicit_triggered) {
     rearm();
     return;
   }
 
-  RebuildSource source = RebuildSource::Periodic;
+  RebuildSource source = RebuildSource::Explicit;
   if (memory_triggered) {
     source = RebuildSource::Memory;
     wasm->markReclaimEligible();
@@ -469,7 +469,7 @@ bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery, RebuildSou
       if (source == RebuildSource::Memory) {
         stats.rebuild_memory_total_.inc();
       } else {
-        stats.rebuild_periodic_total_.inc();
+        stats.rebuild_explicit_total_.inc();
       }
       current_wasm->recordReclaimLatency(now);
       current_wasm->clearReclaimEligible();

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -208,7 +208,7 @@ private:
 using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;
 
 #if defined(HIGRESS)
-enum class RebuildSource { Periodic, Memory };
+enum class RebuildSource { Explicit, Memory };
 
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject,
                                          public Logger::Loggable<Logger::Id::wasm> {
@@ -221,7 +221,7 @@ public:
   PluginHandleSharedPtrThreadLocal() = default;
   ~PluginHandleSharedPtrThreadLocal() override;
 
-  bool rebuild(bool is_fail_recovery = false, RebuildSource source = RebuildSource::Periodic);
+  bool rebuild(bool is_fail_recovery = false, RebuildSource source = RebuildSource::Explicit);
   void runReclaimTimerForTesting();
   PluginHandleSharedPtr& handle() { return handle_; }
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -112,7 +112,7 @@ public:
 
   bool rebuildThroughThreadLocal(PluginHandleSharedPtrThreadLocal& thread_local_handle,
                                  bool is_fail_recovery = false,
-                                 RebuildSource source = RebuildSource::Periodic) {
+                                 RebuildSource source = RebuildSource::Explicit) {
     if (!is_fail_recovery && thread_local_handle.handle() != nullptr &&
         thread_local_handle.handle()->wasmHandle() != nullptr &&
         thread_local_handle.handle()->wasmHandle()->wasm() != nullptr) {
@@ -2448,8 +2448,8 @@ TEST_P(WasmHttpFilterTest, ReclaimTimerRebuildsIdleVmWhenShouldRebuildIsSet) {
   setupTest("", "RebuildTest");
   auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
                                                   ".plugin.plugin_name.rebuild_total");
-  auto& rebuild_periodic_total = scope_->counterFromString(
-      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_periodic_total");
+  auto& rebuild_explicit_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_explicit_total");
   auto& rebuild_memory_total = scope_->counterFromString(
       "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
 
@@ -2463,7 +2463,7 @@ TEST_P(WasmHttpFilterTest, ReclaimTimerRebuildsIdleVmWhenShouldRebuildIsSet) {
   adoptThreadLocalHandle(*thread_local_handle);
 
   EXPECT_EQ(1U, rebuild_total.value());
-  EXPECT_EQ(1U, rebuild_periodic_total.value());
+  EXPECT_EQ(1U, rebuild_explicit_total.value());
   EXPECT_EQ(0U, rebuild_memory_total.value());
   EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
 }
@@ -2480,8 +2480,8 @@ TEST_P(WasmHttpFilterTest, ReclaimTimerUsesMemoryThresholdSourceAndRuntimeOverri
   setupTest("", "RebuildTest");
   auto& rebuild_total = scope_->counterFromString("wasm.envoy.wasm.runtime." + runtime +
                                                   ".plugin.plugin_name.rebuild_total");
-  auto& rebuild_periodic_total = scope_->counterFromString(
-      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_periodic_total");
+  auto& rebuild_explicit_total = scope_->counterFromString(
+      "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_explicit_total");
   auto& rebuild_memory_total = scope_->counterFromString(
       "wasm.envoy.wasm.runtime." + runtime + ".plugin.plugin_name.rebuild_memory_total");
 
@@ -2498,7 +2498,7 @@ TEST_P(WasmHttpFilterTest, ReclaimTimerUsesMemoryThresholdSourceAndRuntimeOverri
   adoptThreadLocalHandle(*thread_local_handle);
 
   EXPECT_EQ(1U, rebuild_total.value());
-  EXPECT_EQ(0U, rebuild_periodic_total.value());
+  EXPECT_EQ(0U, rebuild_explicit_total.value());
   EXPECT_EQ(1U, rebuild_memory_total.value());
   EXPECT_FALSE(old_wasm->shouldRebuild());
   EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());


### PR DESCRIPTION
## Summary

- Rename the plugin-requested rebuild source from `periodic` to `explicit`.
- Rename `RebuildSource::Periodic` to `RebuildSource::Explicit`.
- Rename the per-plugin counter from `rebuild_periodic_total` to `rebuild_explicit_total` and update test expectations.

## Reason

The reclaim timer runs periodically, but this rebuild source is selected when the Wasm plugin explicitly sets the rebuild flag. Calling the source `periodic` was easy to confuse with the timer mechanism itself, so `explicit` better describes the trigger.

## Metrics

`rebuild_total` and `rebuild_memory_total` are unchanged. The plugin-explicit rebuild counter is now reported as `rebuild_explicit_total`.

Example with the Envoy admin Prometheus endpoint:

```bash
curl -s http://127.0.0.1:15000/stats/prometheus | grep rebuild_explicit_total
```

For a plugin stat such as `wasm.envoy.wasm.runtime.v8.plugin.plugin_name.rebuild_explicit_total`, the Prometheus output is expected to look like:

```text
envoy_wasm_envoy_wasm_runtime_v8_plugin_plugin_name_rebuild_explicit_total{} 1
```

The exact metric name still depends on the runtime and plugin name in the active config.

## Verification

All Bazel commands below were run against `envoy-1.36` with:

- `/home/zhangty/work/envoy/clang-18.bazelrc`
- `/home/zhangty/work/envoy/user-1.36.bazelrc`

Passed:

```bash
git diff --check
git clang-format --diff higress/envoy-1.36 -- source/extensions/common/wasm/stats_handler.h source/extensions/common/wasm/wasm.h source/extensions/common/wasm/wasm.cc test/extensions/filters/http/wasm/wasm_filter_test.cc
rg -n 'rebuild_periodic|periodic_triggered|RebuildSource::Periodic|RebuildSource \{ Periodic' source/extensions/common/wasm test/extensions/filters/http/wasm/wasm_filter_test.cc
bazel --bazelrc=/tmp/envoy-higress-1.36-explicit/.bazelrc --bazelrc=/home/zhangty/work/envoy/clang-18.bazelrc --bazelrc=/home/zhangty/work/envoy/user-1.36.bazelrc build --spawn_strategy=local //source/extensions/common/wasm:wasm_lib //source/extensions/filters/http/wasm:wasm_filter_lib
```

Focused Wasm filter test attempted but blocked before test execution by local wasm test-data build failure:

```bash
bazel --bazelrc=/tmp/envoy-higress-1.36-explicit/.bazelrc --bazelrc=/home/zhangty/work/envoy/clang-18.bazelrc --bazelrc=/home/zhangty/work/envoy/user-1.36.bazelrc test --spawn_strategy=local //test/extensions/filters/http/wasm:wasm_filter_test --test_filter='*ReclaimTimerRebuildsIdleVmWhenShouldRebuildIsSet*:*ReclaimTimerUsesMemoryThresholdSourceAndRuntimeOverride*' --test_output=errors
```

The failure is in `//test/extensions/filters/http/wasm/test_data:proxy_wasm_test_cpp`: `proxy_wasm_intrinsics_lite.pb.h` reports that it was generated by a newer protoc version than the available protobuf headers and cannot find `google/protobuf/generated_message_table_driven.h`. Bazel reports `Executed 0 out of 1 test`.