### PR TITLE
Restore original method after Dubbo transcoding

### DIFF
--- a/contrib/http_dubbo_transcoder/filters/http/source/dubbo_transcoder_filter.cc
+++ b/contrib/http_dubbo_transcoder/filters/http/source/dubbo_transcoder_filter.cc
@@ -476,7 +476,9 @@ Http::FilterHeadersStatus TranscodeFilter::decodeHeaders(Http::RequestHeaderMap&
     ENVOY_STREAM_LOG(debug, "sent dubbo frame", *decoder_callbacks_);
   }
 
-  // Modify the request method to use http.tcp connection pools.
+  // CONNECT is only needed on the upstream request path; restore the original
+  // downstream method before Envoy evaluates CONNECT response tunneling.
+  original_method_ = std::string(header.getMethodValue());
   header.setMethod(Http::Headers::get().MethodValues.Connect);
   request_header_ = &header;
   return Http::FilterHeadersStatus::Continue;
@@ -528,6 +530,11 @@ Http::FilterTrailersStatus TranscodeFilter::decodeTrailers(Http::RequestTrailerM
 Http::FilterHeadersStatus TranscodeFilter::encodeHeaders(Http::ResponseHeaderMap& headers, bool) {
   if (transcoder_) {
     headers.setReferenceContentType(ContentTypeHeaderValue);
+    // Prevent the downstream HTTP/1.1 keep-alive connection from being treated
+    // as a CONNECT tunnel after the upstream Dubbo response is encoded.
+    if (request_header_ != nullptr && !original_method_.empty()) {
+      request_header_->setMethod(original_method_);
+    }
   }
   return Http::FilterHeadersStatus::Continue;
 }

--- a/contrib/http_dubbo_transcoder/filters/http/source/dubbo_transcoder_filter.h
+++ b/contrib/http_dubbo_transcoder/filters/http/source/dubbo_transcoder_filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -244,6 +245,7 @@ private:
   std::unique_ptr<Buffer::OwnedImpl> request_body_buffer_{};
 
   bool error_{false};
+  std::string original_method_;
 };
 
 } // namespace HttpDubboTranscoder

--- a/contrib/http_dubbo_transcoder/filters/http/test/dubbo_transcoder_filter_test.cc
+++ b/contrib/http_dubbo_transcoder/filters/http/test/dubbo_transcoder_filter_test.cc
@@ -104,6 +104,22 @@ TEST_F(TranscodeFilterTest, NormalHttpGetMethod) {
   EXPECT_EQ(Http::Headers::get().MethodValues.Connect, request_headers.getMethodValue());
 }
 
+TEST_F(TranscodeFilterTest, RestoreOriginalMethodOnEncodeHeaders) {
+  setConfiguration();
+  setFilter();
+
+  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, true)).Times(1);
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/mytest.service/sayHello?my_param=test"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::Headers::get().MethodValues.Connect, request_headers.getMethodValue());
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_EQ(Http::Headers::get().MethodValues.Get, request_headers.getMethodValue());
+}
+
 TEST_F(TranscodeFilterTest, AllowUnknownMethodAndParameter) {
   setConfiguration();
   setFilter();


### PR DESCRIPTION
## Summary
- Save the original downstream HTTP method before http_dubbo_transcoder switches the request to CONNECT.
- Restore the original method during response header encoding so Envoy does not mark the downstream HTTP/1.1 connection as a CONNECT tunnel.
- Add a regression test that verifies decode keeps CONNECT for the upstream path and encode restores GET.

## Test Plan
- [x] git diff --check
- [ ] npx -y @bazel/bazelisk@latest test //contrib/http_dubbo_transcoder/filters/http/test:dubbo_transcoder_filter_test --test_arg=--gtest_filter='TranscodeFilterTest.RestoreOriginalMethodOnEncodeHeaders' --test_output=all

The Bazel target did not reach compilation locally because external Go module fetches timed out/interrupted while resolving analysis dependencies:
- goproxy.cn: TLS handshake timeout fetching github.com/iancoleman/strcase
- proxy.golang.org: i/o timeout fetching github.com/iancoleman/strcase
- goproxy.io: unexpected EOF fetching golang.org/x/tools

Related: higress-group/higress#3665