### PR TITLE
redis: skip AsyncClient teardown when config is unchanged

### DIFF
--- a/source/common/redis/async_client_impl.cc
+++ b/source/common/redis/async_client_impl.cc
@@ -51,7 +51,25 @@ AsyncClientImpl::~AsyncClientImpl() {
   }
 }
 
+bool AsyncClientImpl::currentConfigEquals(const AsyncClientConfig& incoming) const {
+  // config_ holds the numeric/bool fields; auth/params live on this instance.
+  return auth_username_ == incoming.auth_username_ &&
+         auth_password_ == incoming.auth_password_ && params_ == incoming.params_ &&
+         config_->opTimeout() == incoming.op_timeout_ &&
+         config_->maxBufferSizeBeforeFlush() == incoming.max_buffer_size_before_flush_ &&
+         config_->bufferFlushTimeoutInMs() == incoming.buffer_flush_timeout_ &&
+         config_->maxUpstreamUnknownConnections() == incoming.max_upstream_unknown_connections_ &&
+         config_->enableCommandStats() == incoming.enable_command_stats_;
+}
+
 void AsyncClientImpl::initialize(AsyncClientConfig config) {
+  // Reloading a plugin re-invokes initialize() with the same Redis config. Tearing
+  // down healthy connections in that case fails in-flight requests during the lazy
+  // reconnect window (see higress #4086). Skip teardown when nothing changed.
+  if (initialized_ && currentConfigEquals(config)) {
+    return;
+  }
+
   while (!client_map_.empty()) {
     client_map_.begin()->second->redis_client_->close();
   }
@@ -63,6 +81,7 @@ void AsyncClientImpl::initialize(AsyncClientConfig config) {
   auth_username_ = config.auth_username_;
   auth_password_ = config.auth_password_;
   params_ = config.params_;
+  initialized_ = true;
 }
 
 PoolRequest* AsyncClientImpl::send(std::string&& query, AsyncClient::Callbacks& callbacks,

--- a/source/common/redis/async_client_impl.h
+++ b/source/common/redis/async_client_impl.h
@@ -139,6 +139,11 @@ private:
 
   void onRequestCompleted();
 
+  // Returns true when `incoming` equals the currently installed configuration
+  // (the auth/params members plus the fields held by `config_`). Used by
+  // initialize() to skip connection teardown when nothing changed.
+  bool currentConfigEquals(const AsyncClientConfig& incoming) const;
+
   const std::string cluster_name_;
   Upstream::ThreadLocalCluster* cluster_{};
   Event::Dispatcher& dispatcher_;
@@ -155,6 +160,10 @@ private:
   Event::TimerPtr drain_timer_;
   RawClientFactory& client_factory_;
   ConfigSharedPtr config_;
+  // False until the first initialize() installs a real config. config_ is
+  // non-null from construction (default ConfigImpl), so this flag -- not a null
+  // check -- is what distinguishes the first call from a reload.
+  bool initialized_{false};
   Stats::ScopeSharedPtr stats_scope_;
   RedisCommandStatsSharedPtr redis_command_stats_;
   RedisClusterStats redis_cluster_stats_;

--- a/test/common/redis/BUILD
+++ b/test/common/redis/BUILD
@@ -1,0 +1,22 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "async_client_impl_test",
+    srcs = ["async_client_impl_test.cc"],
+    deps = [
+        "//source/common/redis:async_client_lib",
+        "//source/common/stats:isolated_store_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/redis:redis_mocks",
+        "//test/mocks/upstream:host_mocks",
+        "//test/mocks/upstream:thread_local_cluster_mocks",
+    ],
+)

--- a/test/common/redis/async_client_impl_test.cc
+++ b/test/common/redis/async_client_impl_test.cc
@@ -7,6 +7,7 @@
 #include "source/common/stats/isolated_store_impl.h"
 
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/redis/mocks.h"
 #include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
 
@@ -100,11 +101,15 @@ public:
     EXPECT_EQ(factory_.created_, 1);
   }
 
+  // close_count_ and factory_ are declared before dispatcher_ so they outlive it:
+  // dispatcher_.deferredDelete() retains FakeRawClients in its to_delete_ vector, and
+  // those hold `int& close_count_`. Destruction is reverse-declaration order, so this
+  // ordering guarantees dispatcher_ (and the FakeRawClients it owns) tears down first.
   NiceMock<Upstream::MockThreadLocalCluster> cluster_;
-  NiceMock<Event::MockDispatcher> dispatcher_;
-  Stats::IsolatedStoreImpl stats_;
   int close_count_{0};
   FakeRawClientFactory factory_{close_count_};
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  Stats::IsolatedStoreImpl stats_;
   std::shared_ptr<Upstream::MockHost> host_;
   MockRedisAsyncClientCallbacks callbacks_;
   std::unique_ptr<AsyncClientImpl> client_;
@@ -120,12 +125,11 @@ TEST_F(AsyncClientImplTest, IdenticalConfigSkipsTeardown) {
   EXPECT_EQ(close_count_, 0);        // connection preserved
 }
 
-// SPEC-001: the first initialize() always installs, even if it equals ConfigImpl defaults.
+// SPEC-001: the first initialize() always installs (initialized_ is false), then a
+// subsequent identical call short-circuits.
 TEST_F(AsyncClientImplTest, FirstCallInstallsThenShortCircuits) {
-  // Defaults happen to match ConfigImpl's constructed values; the initialized_ flag,
-  // not value coincidence, is what forces the first call through the install path.
-  auto default_like = makeConfig("", "", 1000, {});
-  client_->initialize(default_like);
+  auto empty_auth = makeConfig("", "", 1000, {});
+  client_->initialize(empty_auth);
   openOneClient();
 
   close_count_ = 0;

--- a/test/common/redis/async_client_impl_test.cc
+++ b/test/common/redis/async_client_impl_test.cc
@@ -1,0 +1,171 @@
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "source/common/redis/async_client_impl.h"
+#include "source/common/stats/isolated_store_impl.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/upstream/host.h"
+#include "test/mocks/upstream/thread_local_cluster.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Redis {
+namespace {
+
+namespace RedisClient = Extensions::NetworkFilters::Common::Redis::Client;
+
+// Minimal RawClient double. close() emulates the real RawClientImpl by invoking the
+// registered ConnectionCallbacks with LocalClose, which is what makes
+// AsyncClientImpl::initialize()'s `while (!client_map_.empty())` loop terminate.
+class FakeRawClient : public RedisClient::RawClient {
+public:
+  explicit FakeRawClient(int& close_count) : close_count_(close_count) {}
+
+  void addConnectionCallbacks(Network::ConnectionCallbacks& callbacks) override {
+    callbacks_ = &callbacks;
+  }
+  bool active() override { return false; }
+  void close() override {
+    ++close_count_;
+    // May delete `this` via deferredDelete + client_map_ erase; touch nothing after.
+    if (callbacks_ != nullptr) {
+      callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
+    }
+  }
+  RedisClient::PoolRequest* makeRawRequest(std::string_view, RedisClient::RawClientCallbacks&) override {
+    return nullptr;
+  }
+  void initialize(const std::string&, const std::string&,
+                  const std::map<std::string, std::string>&) override {}
+
+private:
+  int& close_count_;
+  Network::ConnectionCallbacks* callbacks_{nullptr};
+};
+
+class FakeRawClientFactory : public RedisClient::RawClientFactory {
+public:
+  explicit FakeRawClientFactory(int& close_count) : close_count_(close_count) {}
+
+  RedisClient::RawClientPtr create(Upstream::HostConstSharedPtr, Event::Dispatcher&,
+                                   RedisClient::ConfigSharedPtr,
+                                   const RedisClient::RedisCommandStatsSharedPtr&, Stats::Scope&,
+                                   const std::string&, const std::string&,
+                                   const std::map<std::string, std::string>&) override {
+    ++created_;
+    return std::make_unique<FakeRawClient>(close_count_);
+  }
+
+  int created_{0};
+
+private:
+  int& close_count_;
+};
+
+// Builds an AsyncClientConfig with per-field overrides so tests can flip exactly one field.
+AsyncClientConfig makeConfig(std::string username = "user", std::string password = "pass",
+                             int op_timeout_ms = 1000,
+                             std::map<std::string, std::string> params = {{"a", "1"}, {"b", "2"}}) {
+  return AsyncClientConfig(std::move(username), std::move(password), op_timeout_ms,
+                           std::move(params));
+}
+
+class AsyncClientImplTest : public testing::Test {
+public:
+  AsyncClientImplTest() {
+    host_ = std::make_shared<NiceMock<Upstream::MockHost>>();
+    // HostSelectionResponse is move-only, so build a fresh one per call via Invoke.
+    ON_CALL(cluster_.lb_, chooseHost(_)).WillByDefault(Invoke([this](Upstream::LoadBalancerContext*) {
+      return Upstream::HostSelectionResponse{host_};
+    }));
+    client_ = std::make_unique<AsyncClientImpl>(
+        &cluster_, dispatcher_, factory_, stats_.rootScope(), /*redis_command_stats=*/nullptr,
+        /*refresh_manager=*/nullptr);
+  }
+
+  // Populates client_map_ with one connection so a subsequent teardown is observable.
+  void openOneClient() {
+    factory_.created_ = 0;
+    AsyncClient::RedisRequestOptions options;
+    client_->send("PING", callbacks_, options);
+    EXPECT_EQ(factory_.created_, 1);
+  }
+
+  NiceMock<Upstream::MockThreadLocalCluster> cluster_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  Stats::IsolatedStoreImpl stats_;
+  int close_count_{0};
+  FakeRawClientFactory factory_{close_count_};
+  std::shared_ptr<Upstream::MockHost> host_;
+  MockRedisAsyncClientCallbacks callbacks_;
+  std::unique_ptr<AsyncClientImpl> client_;
+};
+
+// SPEC-001: identical config on reload keeps healthy connections (no close()).
+TEST_F(AsyncClientImplTest, IdenticalConfigSkipsTeardown) {
+  client_->initialize(makeConfig());
+  openOneClient();
+
+  close_count_ = 0;
+  client_->initialize(makeConfig()); // equal to installed config
+  EXPECT_EQ(close_count_, 0);        // connection preserved
+}
+
+// SPEC-001: the first initialize() always installs, even if it equals ConfigImpl defaults.
+TEST_F(AsyncClientImplTest, FirstCallInstallsThenShortCircuits) {
+  // Defaults happen to match ConfigImpl's constructed values; the initialized_ flag,
+  // not value coincidence, is what forces the first call through the install path.
+  auto default_like = makeConfig("", "", 1000, {});
+  client_->initialize(default_like);
+  openOneClient();
+
+  close_count_ = 0;
+  client_->initialize(makeConfig("", "", 1000, {}));
+  EXPECT_EQ(close_count_, 0);
+}
+
+// SPEC-002/003: changing any single field forces the full teardown path.
+TEST_F(AsyncClientImplTest, EachFieldChangeTriggersTeardown) {
+  const std::vector<AsyncClientConfig> changed = {
+      makeConfig("other-user"),
+      makeConfig("user", "other-pass"),
+      makeConfig("user", "pass", 2000),
+      makeConfig("user", "pass", 1000, {{"a", "1"}, {"b", "changed"}}),
+      makeConfig("user", "pass", 1000, {{"a", "1"}}),
+  };
+
+  for (const auto& next : changed) {
+    // Reset to the baseline config with one open connection.
+    client_ = std::make_unique<AsyncClientImpl>(&cluster_, dispatcher_, factory_, stats_.rootScope(),
+                                                nullptr, nullptr);
+    client_->initialize(makeConfig());
+    openOneClient();
+
+    close_count_ = 0;
+    client_->initialize(next);
+    EXPECT_EQ(close_count_, 1) << "expected teardown when a config field differs";
+  }
+}
+
+// SPEC-003: same key/value set built in different insertion order compares equal.
+TEST_F(AsyncClientImplTest, ReorderedParamsAreEqual) {
+  client_->initialize(makeConfig("user", "pass", 1000, {{"a", "1"}, {"b", "2"}}));
+  openOneClient();
+
+  close_count_ = 0;
+  client_->initialize(makeConfig("user", "pass", 1000, {{"b", "2"}, {"a", "1"}}));
+  EXPECT_EQ(close_count_, 0);
+}
+
+} // namespace
+} // namespace Redis
+} // namespace Envoy


### PR DESCRIPTION
## Problem

`AsyncClientImpl::initialize()` unconditionally closes **every** connection in
`client_map_` and `clients_to_drain_` and then rewrites the config — with no
comparison against the currently installed config.

`AsyncClientImpl` is a singleton per `(worker_thread, cluster)`, shared by all
WASM VMs/plugins on that worker. A plugin reload re-invokes `initialize()` with
an **identical** Redis config, so healthy TCP connections are torn down for
every plugin on that worker. In-flight async requests attached to a
just-closed connection then receive `onFailure()` during the lazy-reconnect
window (`threadLocalActiveClient()` only reconnects on the next `send()`).

Tracked in Higress bug higress-group/higress#4086.

## Fix

Short-circuit `initialize()` when the incoming `AsyncClientConfig` equals the
currently installed config, returning **before** touching any connection.

- Equality (`currentConfigEquals`) is compared against the **live installed
  state**: the `auth_username_`/`auth_password_`/`params_` members plus the five
  fields held by `config_`. `ConfigImpl` does not store auth/params, so a
  `ConfigImpl`-only comparison would miss auth changes.
- A dedicated `initialized_` flag distinguishes the first call from a reload.
  `config_` is non-null from construction (default `ConfigImpl`), so a
  `config_ != nullptr` check cannot detect the first call.
- When any field differs, the teardown-and-rewrite path is byte-for-byte
  unchanged.

## Tests

New `test/common/redis/async_client_impl_test.cc`:

- identical config on reload → no `close()` (connection preserved)
- first `initialize()` always installs, even when equal to `ConfigImpl` defaults
- each single field change → full teardown still happens
- params with same key/value set in different insertion order compare equal

## Compatibility

No public API change. When config changes, behavior is identical to before;
when identical, connections survive (the fix).
