### PR TITLE
override_host: report the selected host in dynamic metadata

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/override_host/v3/override_host.proto
+++ b/api/envoy/extensions/load_balancing_policies/override_host/v3/override_host.proto
@@ -36,14 +36,29 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // .. code-block:: yaml
 //
 //    override_host_sources:
-//      - header: "x-gateway-destination-endpoint"
-//      - metadata:
-//          key: "envoy.lb"
-//          path:
-//          - key: "x-gateway-destination-endpoint"
+//    - header: "x-gateway-destination-endpoint"
+//    - metadata:
+//        key: "envoy.lb"
+//        path:
+//        - key: "x-gateway-destination-endpoint"
 //
 // If no valid host in the override host list, then the specified fallback load balancing policy is used. This allows load
 // balancing to degrade to a a built in policy (i.e. Round Robin) in case external endpoint picker fails.
+//
+// In addition to specifying ``override_host_sources``, the policy can be configured to inform downstream filters
+// of the selected endpoint through dynamic metadata using ``selected_host_key``:
+//
+// .. code-block:: yaml
+//
+//    override_host_sources:
+//    - metadata:
+//        key: "envoy.lb"
+//        path:
+//        - key: "x-gateway-destination-endpoint"
+//    selected_host_key:
+//      key: "envoy.lb"
+//      path:
+//      - key: "x-gateway-destination-endpoint-served"
 //
 // See the :ref:`load balancing architecture
 // overview<arch_overview_load_balancing_types>` for more information.
@@ -71,6 +86,10 @@ message OverrideHost {
   // satisfy all retry attempts the fallback load balancing policy is used to pick a host.
   repeated OverrideHostSource override_host_sources = 1
       [(validate.rules).repeated = {min_items: 1}];
+
+  // The metadata key to populate with the selected host address. This is optional and
+  // may be used to inform downstream filters of the host address selected by load balancing policy.
+  type.metadata.v3.MetadataKey selected_host_key = 2;
 
   // The child LB policy to use in case neither header nor metadata with selected
   // hosts is present.

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -48,11 +48,13 @@ using ::Envoy::Upstream::LoadBalancerPtr;
 using ::Envoy::Upstream::TypedLoadBalancerFactory;
 
 OverrideHostLbConfig::OverrideHostLbConfig(std::vector<OverrideSource>&& override_host_sources,
+                                           absl::optional<Config::MetadataKey>&& selected_host_key,
                                            TypedLoadBalancerFactory* fallback_load_balancer_factory,
                                            LoadBalancerConfigPtr&& fallback_load_balancer_config)
     : fallback_picker_lb_config_{fallback_load_balancer_factory,
                                  std::move(fallback_load_balancer_config)},
-      override_host_sources_(std::move(override_host_sources)) {}
+      override_host_sources_(std::move(override_host_sources)),
+      selected_host_key_(std::move(selected_host_key)) {}
 
 OverrideHostLbConfig::OverrideSource
 OverrideHostLbConfig::OverrideSource::make(const OverrideHost::OverrideHostSource& config) {
@@ -87,6 +89,12 @@ OverrideHostLbConfig::make(const OverrideHost& config, ServerFactoryContext& con
   absl::StatusOr<std::vector<OverrideSource>> override_host_sources =
       makeOverrideSources(config.override_host_sources());
   RETURN_IF_NOT_OK(override_host_sources.status());
+
+  absl::optional<Config::MetadataKey> selected_host_key;
+  if (config.has_selected_host_key()) {
+    selected_host_key.emplace(config.selected_host_key());
+  }
+
   ASSERT(config.has_fallback_policy());
   absl::InlinedVector<absl::string_view, 4> missing_policies;
   for (const auto& policy : config.fallback_policy().policies()) {
@@ -102,9 +110,9 @@ OverrideHostLbConfig::make(const OverrideHost& config, ServerFactoryContext& con
 
       auto fallback_load_balancer_config = factory->loadConfig(context, *proto_message);
       RETURN_IF_NOT_OK_REF(fallback_load_balancer_config.status());
-      return std::unique_ptr<OverrideHostLbConfig>(
-          new OverrideHostLbConfig(std::move(override_host_sources).value(), factory,
-                                   std::move(fallback_load_balancer_config.value())));
+      return std::unique_ptr<OverrideHostLbConfig>(new OverrideHostLbConfig(
+          std::move(override_host_sources).value(), std::move(selected_host_key), factory,
+          std::move(fallback_load_balancer_config.value())));
     }
     missing_policies.push_back(policy.typed_extension_config().name());
   }
@@ -145,7 +153,7 @@ OverrideHostLoadBalancer::LoadBalancerImpl::peekAnotherHost(LoadBalancerContext*
 }
 
 HostSelectionResponse
-OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* context) {
+OverrideHostLoadBalancer::LoadBalancerImpl::chooseHostInternal(LoadBalancerContext* context) {
   if (!context || !context->requestStreamInfo()) {
     // If there is no context or no request stream info, we can't use the
     // metadata, so we just return a host from the fallback picker.
@@ -166,7 +174,7 @@ OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* cont
   }
 
   if (override_host_state->empty()) {
-    ENVOY_LOG(trace, "No overriden hosts were found. Using fallback LB policy.");
+    ENVOY_LOG(trace, "No overridden hosts were found. Using fallback LB policy.");
     return fallback_picker_lb_->chooseHost(context);
   }
 
@@ -181,6 +189,39 @@ OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* cont
   ENVOY_LOG(trace, "Failed to find any endpoints from metadata in the cluster. "
                    "Using fallback LB policy.");
   return fallback_picker_lb_->chooseHost(context);
+}
+
+HostSelectionResponse
+OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* context) {
+  auto response = chooseHostInternal(context);
+  addSelectedHostKey(context, response);
+  return response;
+}
+
+void OverrideHostLoadBalancer::LoadBalancerImpl::addSelectedHostKey(
+    LoadBalancerContext* context, HostSelectionResponse& response) {
+  if (!config_.selectedHostKey().has_value() || response.host == nullptr) {
+    return;
+  }
+
+  const Config::MetadataKey& metadata_key = config_.selectedHostKey().value();
+  if (metadata_key.path_.empty()) {
+    // Should not be possible based on proto validation, catching anyways.
+    ENVOY_LOG(trace, "Path was not provided in selected_host_key.");
+    return;
+  }
+
+  Protobuf::Struct updated_metadata;
+  Protobuf::Struct* updated_metadata_ptr = &updated_metadata;
+  for (size_t i = 0; i + 1 < metadata_key.path_.size(); ++i) {
+    Protobuf::Value& current_value =
+        (*updated_metadata_ptr->mutable_fields())[metadata_key.path_[i]];
+    updated_metadata_ptr = current_value.mutable_struct_value();
+  }
+  (*updated_metadata_ptr->mutable_fields())[metadata_key.path_.back()].set_string_value(
+      response.host->address()->asString());
+
+  context->requestStreamInfo()->setDynamicMetadata(metadata_key.key_, updated_metadata);
 }
 
 absl::optional<absl::string_view>

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -200,7 +200,8 @@ OverrideHostLoadBalancer::LoadBalancerImpl::chooseHost(LoadBalancerContext* cont
 
 void OverrideHostLoadBalancer::LoadBalancerImpl::addSelectedHostKey(
     LoadBalancerContext* context, HostSelectionResponse& response) {
-  if (!config_.selectedHostKey().has_value() || response.host == nullptr) {
+  if (!config_.selectedHostKey().has_value() || response.host == nullptr || context == nullptr ||
+      context->requestStreamInfo() == nullptr) {
     return;
   }
 

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.h
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.h
@@ -70,9 +70,11 @@ public:
                                     RandomGenerator& random, TimeSource& time_source) const;
 
   const std::vector<OverrideSource>& overrideHostSources() const { return override_host_sources_; }
+  const absl::optional<Config::MetadataKey>& selectedHostKey() const { return selected_host_key_; }
 
 private:
   OverrideHostLbConfig(std::vector<OverrideSource>&& override_host_sources,
+                       absl::optional<Config::MetadataKey>&& selected_host_key,
                        TypedLoadBalancerFactory* fallback_load_balancer_factory,
                        LoadBalancerConfigPtr&& fallback_load_balancer_config);
 
@@ -88,6 +90,7 @@ private:
   const FallbackLbConfig fallback_picker_lb_config_;
 
   const std::vector<OverrideSource> override_host_sources_;
+  const absl::optional<Config::MetadataKey> selected_host_key_;
 };
 
 // Load balancer for the dynamic forwarding, supporting external endpoint
@@ -147,6 +150,10 @@ private:
   private:
     HostConstSharedPtr getEndpoint(OverrideHostFilterState& override_host_state);
     HostConstSharedPtr findHost(absl::string_view endpoint);
+
+    HostSelectionResponse chooseHostInternal(LoadBalancerContext* context);
+
+    void addSelectedHostKey(LoadBalancerContext* context, HostSelectionResponse& response);
 
     // Lookup the list of endpoints selected by the LbTrafficExtension in the
     // header or in the request metadata.

--- a/test/extensions/load_balancing_policies/override_host/config_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/config_test.cc
@@ -224,6 +224,29 @@ TEST(OverrideHostLbonfigTest, FallbackLbCalledToChooseHost) {
   EXPECT_EQ(host->address()->asString(), "127.0.0.1:80");
 }
 
+TEST(OverrideHostLbonfigTest, ValidSelectedHostKey) {
+  NiceMock<Envoy::Server::Configuration::MockServerFactoryContext> context;
+  ::envoy::config::core::v3::TypedExtensionConfig config;
+  config.set_name("envoy.load_balancers.override_host");
+  OverrideHost config_msg;
+  config_msg.add_override_host_sources()->set_header("x-foo");
+
+  auto* metadata_key = config_msg.mutable_selected_host_key();
+  metadata_key->set_key("envoy.lb");
+  metadata_key->add_path()->set_key("x-gateway-destination-endpoint-served");
+
+  Config fallback_picker_config;
+  auto* typed_extension_config =
+      config_msg.mutable_fallback_policy()->add_policies()->mutable_typed_extension_config();
+  typed_extension_config->mutable_typed_config()->PackFrom(fallback_picker_config);
+  typed_extension_config->set_name("envoy.load_balancing_policies.override_host.test");
+
+  config.mutable_typed_config()->PackFrom(config_msg);
+  auto& factory = Utility::getAndCheckFactory<::Envoy::Upstream::TypedLoadBalancerFactory>(config);
+  auto result = factory.loadConfig(context, config_msg);
+  EXPECT_TRUE(result.ok());
+}
+
 } // namespace
 } // namespace OverrideHost
 } // namespace LoadBalancingPolicies

--- a/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
@@ -809,6 +809,101 @@ TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataPreservesNamespaceSibli
   EXPECT_EQ(metadata_value.string_value(), "false");
 }
 
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostKeyWithNullContextUsesFallback) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  HostConstSharedPtr host = load_balancer_->chooseHost(nullptr).host;
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(host->address()->asString(), "1.2.3.4:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostKeyWithNullRequestStreamInfoUsesFallback) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  EXPECT_CALL(load_balancer_context_, requestStreamInfo()).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(0);
+  HostConstSharedPtr host = load_balancer_->chooseHost(&load_balancer_context_).host;
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(host->address()->asString(), "1.2.3.4:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataStoresFallbackHost) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(testing::AtLeast(1));
+  HostConstSharedPtr host = load_balancer_->chooseHost(&load_balancer_context_).host;
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(host->address()->asString(), "1.2.3.4:80");
+
+  const Protobuf::Value& metadata_value = ::Envoy::Config::Metadata::metadataValue(
+      &load_balancer_context_.requestStreamInfo()->dynamicMetadata(), "envoy.lb",
+      "x-gateway-destination-endpoint-served");
+  EXPECT_EQ(metadata_value.string_value(), "1.2.3.4:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataStoresBracketedIpv6Host) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://[2001:db8::1]:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  setSelectedEndpointsMetadata("envoy.lb", R"pb(
+    fields {
+      key: "x-gateway-destination-endpoint"
+      value: { string_value: "[2001:db8::1]:80" }
+    }
+  )pb");
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(testing::AtLeast(1));
+  HostConstSharedPtr host = load_balancer_->chooseHost(&load_balancer_context_).host;
+  ASSERT_NE(host, nullptr);
+  EXPECT_EQ(host->address()->asString(), "[2001:db8::1]:80");
+
+  const Protobuf::Value& metadata_value = ::Envoy::Config::Metadata::metadataValue(
+      &load_balancer_context_.requestStreamInfo()->dynamicMetadata(), "envoy.lb",
+      "x-gateway-destination-endpoint-served");
+  EXPECT_EQ(metadata_value.string_value(), "[2001:db8::1]:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataDoesNotWriteForNullHost) {
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(0);
+  EXPECT_EQ(load_balancer_->chooseHost(&load_balancer_context_).host, nullptr);
+}
+
 } // namespace
 } // namespace OverrideHost
 } // namespace LoadBalancingPolicies

--- a/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
@@ -46,6 +46,11 @@ public:
     ON_CALL(load_balancer_context_, requestStreamInfo()).WillByDefault(Return(&stream_info_));
     ON_CALL(load_balancer_context_, downstreamHeaders())
         .WillByDefault(Return(&downstream_headers_));
+    ON_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_))
+        .WillByDefault(
+            testing::Invoke([this](const std::string& name, const Protobuf::Struct& value) {
+              (*metadata_.mutable_filter_metadata())[std::string(name)].MergeFrom(value);
+            }));
   }
 
 protected:
@@ -122,6 +127,14 @@ protected:
         config.mutable_fallback_policy()->add_policies()->mutable_typed_extension_config();
     typed_extension_config->mutable_typed_config()->PackFrom(locality_picker_config);
     typed_extension_config->set_name("envoy.load_balancing_policies.override_host.test");
+    return config;
+  }
+
+  OverrideHost makeDefaultConfigWithSelectedHostKey(absl::string_view selected_host_key_name) {
+    OverrideHost config = makeDefaultConfig();
+    auto* metadata_key = config.mutable_selected_host_key();
+    metadata_key->set_key("envoy.lb");
+    metadata_key->add_path()->set_key(selected_host_key_name);
     return config;
   }
 
@@ -703,6 +716,97 @@ TEST_F(OverrideHostLoadBalancerTest, NullDownstreamHeaders) {
   EXPECT_CALL(load_balancer_context_, downstreamHeaders()).WillRepeatedly(Return(nullptr));
   // Even though metadata is invalid, the fallback LB will be used to select a host.
   EXPECT_NE(load_balancer_->chooseHost(&load_balancer_context_).host, nullptr);
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostStoredInMetadata) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  setSelectedEndpointsMetadata("envoy.lb", R"pb(
+    fields {
+      key: "x-gateway-destination-endpoint"
+      value: { string_value: "1.2.3.4:80" }
+    }
+  )pb");
+
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(testing::AtLeast(1));
+  HostConstSharedPtr host = load_balancer_->chooseHost(&load_balancer_context_).host;
+  EXPECT_EQ(host->address()->asString(), "1.2.3.4:80");
+
+  const Protobuf::Value& metadata_value = ::Envoy::Config::Metadata::metadataValue(
+      &load_balancer_context_.requestStreamInfo()->dynamicMetadata(), "envoy.lb",
+      "x-gateway-destination-endpoint-served");
+  EXPECT_EQ(metadata_value.string_value(), "1.2.3.4:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataTracksFinalHost) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://5.6.7.8:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::HEALTHY),
+      Envoy::Upstream::makeTestHost(cluster_info_, "tcp://3.5.8.13:80", us_central1_a, 1, 0,
+                                    Host::HealthStatus::DEGRADED)};
+  host_set->hosts_per_locality_ =
+      ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}, {host_set->hosts_[1]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  setSelectedEndpointsMetadata("envoy.lb", R"pb(
+    fields {
+      key: "x-gateway-destination-endpoint"
+      value: { string_value: "3.5.8.13:80,5.6.7.8:80" }
+    }
+  )pb");
+
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(testing::AtLeast(2));
+  EXPECT_EQ(load_balancer_->chooseHost(&load_balancer_context_).host->address()->asString(),
+            "3.5.8.13:80");
+  EXPECT_EQ(load_balancer_->chooseHost(&load_balancer_context_).host->address()->asString(),
+            "5.6.7.8:80");
+
+  const Protobuf::Value& metadata_value = ::Envoy::Config::Metadata::metadataValue(
+      &load_balancer_context_.requestStreamInfo()->dynamicMetadata(), "envoy.lb",
+      "x-gateway-destination-endpoint-served");
+  EXPECT_EQ(metadata_value.string_value(), "5.6.7.8:80");
+}
+
+TEST_F(OverrideHostLoadBalancerTest, SelectedHostMetadataPreservesNamespaceSiblings) {
+  Locality us_central1_a = makeLocality("us-central1", "us-central1-a");
+  MockHostSet* host_set = thread_local_priority_set_.getMockHostSet(0);
+  host_set->hosts_ = {Envoy::Upstream::makeTestHost(
+      cluster_info_, "tcp://1.2.3.4:80", us_central1_a, 1, 0, Host::HealthStatus::HEALTHY)};
+  host_set->hosts_per_locality_ = ::Envoy::Upstream::makeHostsPerLocality({{host_set->hosts_[0]}});
+  makeCrossPriorityHostMap();
+
+  createLoadBalancer(makeDefaultConfigWithSelectedHostKey(
+      "x-gateway-destination-endpoint-served"));
+  setSelectedEndpointsMetadata("envoy.lb", R"pb(
+    fields {
+      key: "x-gateway-destination-endpoint"
+      value: { string_value: "1.2.3.4:80" }
+    }
+  )pb");
+  Protobuf::Struct sibling_metadata;
+  (*sibling_metadata.mutable_fields())["canary"].set_string_value("false");
+  stream_info_.setDynamicMetadata("envoy.lb", sibling_metadata);
+
+  EXPECT_CALL(stream_info_, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata_));
+  EXPECT_CALL(stream_info_, setDynamicMetadata(testing::_, testing::_)).Times(testing::AtLeast(1));
+  load_balancer_->chooseHost(&load_balancer_context_);
+
+  const Protobuf::Value& metadata_value = ::Envoy::Config::Metadata::metadataValue(
+      &load_balancer_context_.requestStreamInfo()->dynamicMetadata(), "envoy.lb", "canary");
+  EXPECT_EQ(metadata_value.string_value(), "false");
 }
 
 } // namespace


### PR DESCRIPTION
## What changed

- add selected_host_key to the override-host load balancer config;
- write the address of the host actually selected by Envoy to envoy.lb dynamic metadata;
- only report metadata for a valid final host and preserve fallback behavior;
- add config, load-balancer, and integration coverage.

## Why

Gateway API Inference Extension v1.4.0 includes GatewayDestinationEndpointServed. Its verifier reads x-gateway-destination-endpoint-served from dynamic metadata after load balancing. Envoy 1.36 does not contain this behavior.

This is a minimal Envoy 1.36 backport of the upstream implementation in envoyproxy/envoy@a7589bb1428fa2cf40766a19b2f047303a3cddc4, allowing Higress to keep Envoy 1.36.

## Validation

- override-host config, load-balancer, and integration Bazel tests: 3/3 passed;
- ACK, Envoy 1.36.4, GIE v1.4.0 exact tag, Gateway API v1.5.0 standard;
- full GIE conformance: 12 passed, 0 failed, 0 skipped;
- report SHA256: fdb009a16ade03b6d4751f99500e286eee738b18dea69cc1ff601eab15752620.

Related: higress-group/higress#4280
