### PR TITLE
[envoy-1.27] wasm: backport worker recovery and rolling rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ distribution/custom
 examples/websocket/certs
 /contrib/golang/**/test_data/go.sum
 /contrib/golang/**/test_data/*/go.sum
+user*.bazelrc
+clang*.bazelrc

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1362,8 +1362,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
         project_desc = "WebAssembly for Proxies (C++ host implementation)",
         project_url = "https://github.com/higress-group/proxy-wasm-cpp-host",
-        version = "04ef279d83a39d507d882bb35e3199abcecfe5af",
-        sha256 = "2573ecab4f3c12c10a61f2e34a69a3c4d6f20525c9ae07bcaac72b0a9921df78",
+        # Latest master revision containing worker-local Wasm failure isolation.
+        version = "d9c558753df6781388e36e0d51adc98c0b6835a0",
+        sha256 = "75c6572c180ea07779d55671a74864c6c5f8a4a3c15e8c6de88b1fc46ff77797",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
         urls = ["https://github.com/higress-group/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
@@ -1379,7 +1380,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.wasm.runtime.wavm",
             "envoy.wasm.runtime.wasmtime",
         ],
-        release_date = "2024-05-18",
+        release_date = "2026-08-11",
         cpe = "N/A",
     ),
     proxy_wasm_rust_sdk = dict(

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "envoy/server/lifecycle_notifier.h"
+
 #ifdef HIGRESS
 #include "envoy/stats/histogram.h"
 #endif
@@ -55,8 +56,20 @@ struct CreateWasmStats {
 #ifdef HIGRESS
 #define RUNTIME_STATS(PLUGIN_GAUGE) PLUGIN_GAUGE(memory_size, NeverImport)
 
+#define WORKER_INIT_STATS(COUNTER, GAUGE)                                                          \
+  COUNTER(worker_init_retryable_failure_total)                                                     \
+  COUNTER(worker_init_terminal_failure_total)                                                      \
+  COUNTER(worker_init_retry_total)                                                                 \
+  COUNTER(worker_init_recovered_total)                                                             \
+  COUNTER(worker_fail_open_skip_total)                                                             \
+  GAUGE(worker_uninitialized, NeverImport)
+
 struct RuntimeStats {
   RUNTIME_STATS(GENERATE_GAUGE_STRUCT)
+};
+
+struct WorkerInitStats {
+  WORKER_INIT_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 #endif
 
@@ -174,6 +187,27 @@ public:
 protected:
   RuntimeStats runtime_stats_;
 };
+
+class WorkerInitStatsHandler {
+public:
+  WorkerInitStatsHandler(const Stats::ScopeSharedPtr& scope, const std::string& runtime,
+                         const std::string& plugin_name)
+      : scope_(scope),
+        worker_init_stats_(WorkerInitStats{WORKER_INIT_STATS(
+            POOL_COUNTER_PREFIX(*scope_,
+                                absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")),
+            POOL_GAUGE_PREFIX(*scope_,
+                              absl::StrCat("wasm.", runtime, ".plugin.", plugin_name, ".")))}) {}
+
+  WorkerInitStats& stats() { return worker_init_stats_; }
+
+private:
+  // Keep the scope alive for the lifetime of the references stored in worker_init_stats_.
+  Stats::ScopeSharedPtr scope_;
+  WorkerInitStats worker_init_stats_;
+};
+
+using WorkerInitStatsHandlerSharedPtr = std::shared_ptr<WorkerInitStatsHandler>;
 #endif
 
 } // namespace Wasm

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -50,6 +50,18 @@ private:
   std::unique_ptr<Config::DataFetcher::RemoteDataFetcher> fetcher_;
 };
 
+#ifdef HIGRESS
+// Base Wasm handles are shared by the main thread and every worker clone. Keep final destruction
+// on the owning (main) dispatcher even when the last worker TLS wrapper owns the final reference.
+class BaseWasmHandleDispatcherThreadDeletable : public Event::DispatcherThreadDeletable {
+public:
+  explicit BaseWasmHandleDispatcherThreadDeletable(WasmHandle* handle) : handle_(handle) {}
+
+private:
+  std::unique_ptr<WasmHandle> handle_;
+};
+#endif
+
 const std::string INLINE_STRING = "<inline>";
 const int CODE_CACHE_SECONDS_NEGATIVE_CACHING = 10;
 const int CODE_CACHE_SECONDS_CACHING_TTL = 24 * 3600; // 24 hours.
@@ -88,7 +100,48 @@ WasmEvent failStateToWasmEvent(FailState state) {
   PANIC("corrupt enum");
 }
 
-const int MIN_RECOVER_INTERVAL_SECONDS = 1;
+absl::string_view failStateName(FailState state) {
+  switch (state) {
+  case FailState::Ok:
+    return "Ok";
+  case FailState::UnableToCreateVm:
+    return "UnableToCreateVm";
+  case FailState::UnableToCloneVm:
+    return "UnableToCloneVm";
+  case FailState::MissingFunction:
+    return "MissingFunction";
+  case FailState::UnableToInitializeCode:
+    return "UnableToInitializeCode";
+  case FailState::StartFailed:
+    return "StartFailed";
+  case FailState::ConfigureFailed:
+    return "ConfigureFailed";
+  case FailState::RuntimeError:
+    return "RuntimeError";
+  case FailState::RecoverError:
+    return "RecoverError";
+  }
+  return "Unknown";
+}
+
+bool isRetryableWorkerInitializationFailure(FailState state) {
+  switch (state) {
+  case FailState::UnableToCreateVm:
+  case FailState::UnableToCloneVm:
+  case FailState::UnableToInitializeCode:
+  case FailState::RuntimeError:
+    return true;
+  case FailState::Ok:
+  case FailState::MissingFunction:
+  case FailState::StartFailed:
+  case FailState::ConfigureFailed:
+  case FailState::RecoverError:
+    return false;
+  }
+  return false;
+}
+
+constexpr std::chrono::seconds kRecoveryGuardInterval{1};
 constexpr uint64_t DefaultReclaimMemoryThresholdBytes = 800ULL * 1024 * 1024;
 constexpr absl::string_view ReclaimMemoryThresholdRuntimeKey =
     "envoy.wasm.reclaim.memory_threshold_bytes";
@@ -98,7 +151,7 @@ MonotonicTime effectiveMonotonicTime(Event::Dispatcher& dispatcher) {
 }
 
 struct RebuildGuardEntry {
-  MonotonicTime last_recover_time;
+  absl::optional<MonotonicTime> last_recover_time;
   std::weak_ptr<WasmHandle> current_wasm_handle;
   std::vector<std::weak_ptr<WasmHandle>> old_wasm_handles;
 
@@ -130,27 +183,60 @@ struct RebuildGuardEntry {
     old_wasm_handles.push_back(old_wasm_handle);
   }
 
-  bool canRetire() {
+  bool canRetire(MonotonicTime now) {
     pruneExpired();
-    return current_wasm_handle.expired() && old_wasm_handles.empty();
+    if (!current_wasm_handle.expired() || !old_wasm_handles.empty()) {
+      return false;
+    }
+    // A worker initialization retry can record a recovery attempt without creating a Wasm
+    // generation. Retain that otherwise-empty entry through the cooldown so a new wrapper cannot
+    // bypass request recovery throttling by recreating the entry.
+    return !last_recover_time.has_value() ||
+           now - last_recover_time.value() >= kRecoveryGuardInterval;
   }
 };
 
 thread_local absl::flat_hash_map<std::string, RebuildGuardEntry> rebuild_guard_registry;
 
-void sweepRebuildGuardRegistry(const std::string& active_vm_key) {
+void sweepRebuildGuardRegistry(const std::string& active_vm_key, MonotonicTime now) {
   for (auto it = rebuild_guard_registry.begin(); it != rebuild_guard_registry.end();) {
     if (it->first == active_vm_key) {
       ++it;
       continue;
     }
-    if (it->second.canRetire()) {
+    if (it->second.canRetire(now)) {
       auto erase_it = it++;
       rebuild_guard_registry.erase(erase_it);
     } else {
       ++it;
     }
   }
+}
+
+RebuildGuardEntry& rebuildGuardEntry(const std::string& vm_key, MonotonicTime now) {
+  sweepRebuildGuardRegistry(vm_key, now);
+  return rebuild_guard_registry[vm_key];
+}
+
+struct RecoveryPermit {
+  bool acquired;
+  std::chrono::milliseconds remaining;
+};
+
+RecoveryPermit acquireRecoveryPermit(RebuildGuardEntry& guard, MonotonicTime now) {
+  if (guard.last_recover_time.has_value()) {
+    const auto elapsed = now - guard.last_recover_time.value();
+    if (elapsed < kRecoveryGuardInterval) {
+      const auto remaining = kRecoveryGuardInterval - elapsed;
+      auto remaining_ms = std::chrono::duration_cast<std::chrono::milliseconds>(remaining);
+      if (remaining_ms < remaining) {
+        remaining_ms += std::chrono::milliseconds(1);
+      }
+      return {false, remaining_ms};
+    }
+  }
+  guard.last_recover_time = now;
+  return {true, std::chrono::milliseconds(0)};
 }
 #endif
 
@@ -312,6 +398,11 @@ void Wasm::tickHandler(uint32_t root_context_id) {
 }
 
 Wasm::~Wasm() {
+#ifdef HIGRESS
+  ENVOY_BUG(dispatcher_.isThreadSafe(),
+            fmt::format("Wasm owned by dispatcher '{}' was destroyed from another thread",
+                        dispatcher_.name()));
+#endif
   lifecycle_stats_handler_.onEvent(WasmEvent::VmShutDown);
 #ifdef HIGRESS
   if (runtime_stats_timer_) {
@@ -333,14 +424,60 @@ PluginHandleSharedPtrThreadLocal::PluginHandleSharedPtrThreadLocal(PluginHandleS
   initializeReclaimTimer();
 }
 
+PluginHandleSharedPtrThreadLocal::PluginHandleSharedPtrThreadLocal(
+    ThreadLocalPluginResult result, PluginSharedPtr plugin, WasmHandleSharedPtr base_wasm,
+    Event::Dispatcher& dispatcher, WorkerInitStatsHandlerSharedPtr worker_init_stats,
+    bool enable_reclaim_timer, ThreadLocalPluginResultFactory retry_factory,
+    PluginInitializationRole initialization_role)
+    : plugin_(std::move(plugin)), base_wasm_(std::move(base_wasm)), dispatcher_(&dispatcher),
+      worker_init_stats_(initialization_role == PluginInitializationRole::RequestWorker
+                             ? std::move(worker_init_stats)
+                             : nullptr),
+      retry_factory_(initialization_role == PluginInitializationRole::RequestWorker
+                         ? std::move(retry_factory)
+                         : nullptr),
+      reclaim_timer_enabled_(enable_reclaim_timer),
+      initialization_state_(initialization_role == PluginInitializationRole::RequestWorker &&
+                                    result.handle == nullptr
+                                ? PluginInitializationState::Uninitialized
+                                : PluginInitializationState::Ready),
+      last_initialization_failure_(result.fail_state),
+      initialization_failure_retryable_(initialization_role ==
+                                            PluginInitializationRole::RequestWorker &&
+                                        isRetryableWorkerInitializationFailure(result.fail_state)),
+      initialization_role_(initialization_role),
+      handle_(result.handle != nullptr ? std::move(result.handle)
+                                       : std::make_shared<PluginHandle>(nullptr, plugin_)) {
+  if (initialization_state_ == PluginInitializationState::Uninitialized) {
+    recordInitializationFailure();
+    if (worker_init_stats_ != nullptr) {
+      worker_init_stats_->stats().worker_uninitialized_.inc();
+      counted_uninitialized_ = true;
+    }
+    ENVOY_LOG(warn,
+              "wasm worker initialization failed: plugin='{}' reason='{}' retryable={} "
+              "fail_open={}",
+              plugin_ != nullptr ? plugin_->name_ : "", failStateName(last_initialization_failure_),
+              initialization_failure_retryable_, plugin_ != nullptr && plugin_->fail_open_);
+  }
+  initializeReclaimTimer();
+}
+
 PluginHandleSharedPtrThreadLocal::~PluginHandleSharedPtrThreadLocal() {
   if (reclaim_timer_) {
     reclaim_timer_->disableTimer();
   }
+  leaveUninitialized();
 }
 
 void PluginHandleSharedPtrThreadLocal::initializeReclaimTimer() {
+  if (initialization_state_ != PluginInitializationState::Ready) {
+    return;
+  }
   if (!reclaim_timer_enabled_) {
+    return;
+  }
+  if (reclaim_timer_ != nullptr) {
     return;
   }
   if (handle_ == nullptr || handle_->wasmHandle() == nullptr ||
@@ -352,7 +489,113 @@ void PluginHandleSharedPtrThreadLocal::initializeReclaimTimer() {
   reclaim_timer_->enableTimer(kReclaimTimerInterval);
 }
 
+void PluginHandleSharedPtrThreadLocal::recordInitializationFailure() {
+  if (worker_init_stats_ == nullptr) {
+    return;
+  }
+  if (initialization_failure_retryable_) {
+    worker_init_stats_->stats().worker_init_retryable_failure_total_.inc();
+  } else {
+    worker_init_stats_->stats().worker_init_terminal_failure_total_.inc();
+  }
+}
+
+void PluginHandleSharedPtrThreadLocal::leaveUninitialized() {
+  if (!counted_uninitialized_) {
+    return;
+  }
+  ASSERT(worker_init_stats_ != nullptr);
+  worker_init_stats_->stats().worker_uninitialized_.dec();
+  counted_uninitialized_ = false;
+}
+
+PluginInitializationRecoveryResult PluginHandleSharedPtrThreadLocal::tryInitialize() {
+  if (initialization_role_ == PluginInitializationRole::MainThread) {
+    return {PluginInitializationRecoveryStatus::TerminalFailure, std::chrono::milliseconds(0)};
+  }
+  if (initialization_state_ != PluginInitializationState::Uninitialized) {
+    return {PluginInitializationRecoveryStatus::Recovered, std::chrono::milliseconds(0)};
+  }
+  if (!initialization_failure_retryable_) {
+    return {PluginInitializationRecoveryStatus::TerminalFailure, std::chrono::milliseconds(0)};
+  }
+  if (dispatcher_ == nullptr || ((base_wasm_ == nullptr || base_wasm_->wasm() == nullptr) &&
+                                 recovery_vm_key_for_testing_.empty())) {
+    ENVOY_BUG(false, "retryable Wasm worker initialization is missing its recovery context");
+    return {PluginInitializationRecoveryStatus::RetryableFailure, std::chrono::milliseconds(0)};
+  }
+
+  const std::string vm_key = recovery_vm_key_for_testing_.empty()
+                                 ? std::string(base_wasm_->wasm()->vm_key())
+                                 : recovery_vm_key_for_testing_;
+  const auto now = effectiveMonotonicTime(*dispatcher_);
+  auto& guard = rebuildGuardEntry(vm_key, now);
+  const auto permit = acquireRecoveryPermit(guard, now);
+  if (!permit.acquired) {
+    ENVOY_LOG(debug,
+              "wasm worker initialization request retry skipped: plugin='{}' "
+              "remaining_cooldown_ms={}",
+              plugin_ != nullptr ? plugin_->name_ : "", permit.remaining.count());
+    return {PluginInitializationRecoveryStatus::CoolingDown, permit.remaining};
+  }
+
+  ++initialization_retry_attempts_;
+  if (worker_init_stats_ != nullptr) {
+    worker_init_stats_->stats().worker_init_retry_total_.inc();
+  }
+  ThreadLocalPluginResult result =
+      retry_factory_ != nullptr
+          ? retry_factory_()
+          : getOrCreateThreadLocalPluginWithResult(base_wasm_, plugin_, *dispatcher_);
+
+  if (result.handle != nullptr) {
+    guard.trackCurrentGeneration(result.handle->wasmHandle());
+    handle_ = std::move(result.handle);
+    initialization_state_ = PluginInitializationState::Ready;
+    last_initialization_failure_ = FailState::Ok;
+    initialization_failure_retryable_ = false;
+    leaveUninitialized();
+    if (worker_init_stats_ != nullptr) {
+      worker_init_stats_->stats().worker_init_recovered_total_.inc();
+    }
+    ENVOY_LOG(info, "wasm worker initialization recovered: plugin='{}' attempt={}",
+              plugin_ != nullptr ? plugin_->name_ : "", initialization_retry_attempts_);
+    initializeReclaimTimer();
+    return {PluginInitializationRecoveryStatus::Recovered, std::chrono::milliseconds(0)};
+  }
+
+  last_initialization_failure_ = result.fail_state;
+  initialization_failure_retryable_ =
+      isRetryableWorkerInitializationFailure(last_initialization_failure_);
+  recordInitializationFailure();
+
+  if (!initialization_failure_retryable_) {
+    ENVOY_LOG(warn,
+              "wasm worker initialization retry became terminal: plugin='{}' reason='{}' "
+              "attempt={} fail_open={}",
+              plugin_ != nullptr ? plugin_->name_ : "", failStateName(last_initialization_failure_),
+              initialization_retry_attempts_, plugin_ != nullptr && plugin_->fail_open_);
+    return {PluginInitializationRecoveryStatus::TerminalFailure, std::chrono::milliseconds(0)};
+  }
+
+  ENVOY_LOG(debug,
+            "wasm worker initialization request retry failed: plugin='{}' reason='{}' attempt={} "
+            "cooldown_ms={} fail_open={}",
+            plugin_ != nullptr ? plugin_->name_ : "", failStateName(last_initialization_failure_),
+            initialization_retry_attempts_,
+            std::chrono::duration_cast<std::chrono::milliseconds>(kRecoveryGuardInterval).count(),
+            plugin_ != nullptr && plugin_->fail_open_);
+  return {PluginInitializationRecoveryStatus::RetryableFailure, std::chrono::milliseconds(0)};
+}
+
 void PluginHandleSharedPtrThreadLocal::runReclaimTimerForTesting() { onReclaimTimer(); }
+
+void PluginHandleSharedPtrThreadLocal::recordFailOpenSkip() {
+  if (initialization_state_ == PluginInitializationState::Uninitialized && plugin_ != nullptr &&
+      plugin_->fail_open_ && worker_init_stats_ != nullptr) {
+    worker_init_stats_->stats().worker_fail_open_skip_total_.inc();
+  }
+}
 
 void PluginHandleSharedPtrThreadLocal::onReclaimTimer() {
   auto rearm = [this]() {
@@ -432,27 +675,20 @@ bool PluginHandleSharedPtrThreadLocal::rebuild(bool is_fail_recovery, RebuildSou
   }
   current_wasm_handle = handle_->wasmHandle();
   current_wasm = current_wasm_handle->wasm();
-  sweepRebuildGuardRegistry(vm_key);
-  auto& guard = rebuild_guard_registry[vm_key];
-  guard.trackCurrentGeneration(current_wasm_handle);
   auto& dispatcher = current_wasm->dispatcher();
-  auto now = effectiveMonotonicTime(dispatcher);
-  if (now - guard.last_recover_time < std::chrono::seconds(MIN_RECOVER_INTERVAL_SECONDS)) {
-    ENVOY_LOG(info, "wasm vm rebuild skipped: recover interval has not been reached");
-    return false;
-  }
+  const auto now = effectiveMonotonicTime(dispatcher);
+  auto& guard = rebuildGuardEntry(vm_key, now);
+  guard.trackCurrentGeneration(current_wasm_handle);
   if (!is_fail_recovery && guard.hasLiveOldGeneration(current_wasm_handle)) {
-    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: live generation cap reached");
+    ENVOY_LOG(debug, "wasm vm proactive rebuild skipped: live generation cap reached");
     return false;
   }
-  const auto active_stream_count = current_wasm->activeStreamCount();
-  if (!is_fail_recovery && active_stream_count > 0) {
-    ENVOY_LOG(info, "wasm vm proactive rebuild skipped: current generation has {} active streams",
-              active_stream_count);
+  const auto permit = acquireRecoveryPermit(guard, now);
+  if (!permit.acquired) {
+    ENVOY_LOG(debug, "wasm vm rebuild skipped: recovery cooldown has {}ms remaining",
+              permit.remaining.count());
     return false;
   }
-  // Even if rebuild fails, it will be retried after the interval
-  guard.last_recover_time = now;
   std::shared_ptr<PluginHandleBase> new_handle;
   if (handle_->rebuild(new_handle) && new_handle != nullptr) {
     auto new_plugin_handle = std::static_pointer_cast<PluginHandle>(new_handle);
@@ -588,6 +824,12 @@ void clearCodeCacheForTesting() {
 
 #if defined(HIGRESS)
 size_t rebuildGuardRegistrySizeForTesting() { return rebuild_guard_registry.size(); }
+
+bool acquireRecoveryPermitForTesting(absl::string_view vm_key, Event::Dispatcher& dispatcher) {
+  const auto now = effectiveMonotonicTime(dispatcher);
+  auto& guard = rebuildGuardEntry(std::string(vm_key), now);
+  return acquireRecoveryPermit(guard, now).acquired;
+}
 #endif
 
 // TODO: remove this post #4160: Switch default to SimulatedTimeSystem.
@@ -618,7 +860,16 @@ getWasmHandleFactory(WasmConfig& wasm_config, const Stats::ScopeSharedPtr& scope
 #endif
     );
     wasm->initializeLifecycle(lifecycle_notifier);
+#ifdef HIGRESS
+    auto handle =
+        WasmHandleSharedPtr(new WasmHandle(std::move(wasm)), [&dispatcher](WasmHandle* handle) {
+          dispatcher.deleteInDispatcherThread(
+              std::make_unique<BaseWasmHandleDispatcherThreadDeletable>(handle));
+        });
+    return std::static_pointer_cast<WasmHandleBase>(std::move(handle));
+#else
     return std::static_pointer_cast<WasmHandleBase>(std::make_shared<WasmHandle>(std::move(wasm)));
+#endif
   };
 }
 
@@ -860,6 +1111,26 @@ getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginS
       getWasmHandleCloneFactory(dispatcher, create_root_context_for_testing),
       getPluginHandleFactory()));
 }
+
+#if defined(HIGRESS)
+ThreadLocalPluginResult
+getOrCreateThreadLocalPluginWithResult(const WasmHandleSharedPtr& base_wasm,
+                                       const PluginSharedPtr& plugin, Event::Dispatcher& dispatcher,
+                                       CreateContextFn create_root_context_for_testing) {
+  if (!base_wasm) {
+    return {getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher,
+                                         create_root_context_for_testing),
+            FailState::Ok};
+  }
+  auto result = proxy_wasm::getOrCreateThreadLocalPluginWithResult(
+      std::static_pointer_cast<WasmHandle>(base_wasm), plugin,
+      getWasmHandleCloneFactory(dispatcher, create_root_context_for_testing),
+      getPluginHandleFactory());
+  return {result.handle != nullptr ? std::static_pointer_cast<PluginHandle>(result.handle)
+                                   : nullptr,
+          result.fail_state};
+}
+#endif
 
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -8,6 +8,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/extensions/wasm/v3/wasm.pb.validate.h"
 #include "envoy/http/filter.h"
+
 #if defined(HIGRESS)
 #include "envoy/runtime/runtime.h"
 #endif
@@ -208,6 +209,26 @@ using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;
 
 #if defined(HIGRESS)
 enum class RebuildSource { Explicit, Memory };
+enum class PluginInitializationState { Ready, Uninitialized };
+enum class PluginInitializationRole { RequestWorker, MainThread };
+enum class PluginInitializationRecoveryStatus {
+  Recovered,
+  RetryableFailure,
+  TerminalFailure,
+  CoolingDown
+};
+
+struct PluginInitializationRecoveryResult {
+  PluginInitializationRecoveryStatus status;
+  std::chrono::milliseconds remaining_cooldown{0};
+};
+
+struct ThreadLocalPluginResult {
+  PluginHandleSharedPtr handle;
+  proxy_wasm::FailState fail_state{proxy_wasm::FailState::Ok};
+};
+
+using ThreadLocalPluginResultFactory = std::function<ThreadLocalPluginResult()>;
 
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject,
                                          public Logger::Loggable<Logger::Id::wasm> {
@@ -215,9 +236,29 @@ public:
   PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr handle,
                                    WasmHandleSharedPtr base_wasm = nullptr,
                                    bool enable_reclaim_timer = false);
+  PluginHandleSharedPtrThreadLocal(
+      ThreadLocalPluginResult result, PluginSharedPtr plugin, WasmHandleSharedPtr base_wasm,
+      Event::Dispatcher& dispatcher, WorkerInitStatsHandlerSharedPtr worker_init_stats,
+      bool enable_reclaim_timer = false,
+      // Testing-only override; production retries through
+      // getOrCreateThreadLocalPluginWithResult when this is null.
+      ThreadLocalPluginResultFactory retry_factory = nullptr,
+      PluginInitializationRole initialization_role = PluginInitializationRole::RequestWorker);
   ~PluginHandleSharedPtrThreadLocal() override;
+  PluginInitializationRecoveryResult tryInitialize();
   bool rebuild(bool is_fail_recovery = false, RebuildSource source = RebuildSource::Explicit);
   void runReclaimTimerForTesting();
+  PluginInitializationState initializationState() const { return initialization_state_; }
+  proxy_wasm::FailState lastInitializationFailure() const { return last_initialization_failure_; }
+  bool initializationFailureRetryable() const { return initialization_failure_retryable_; }
+  uint64_t initializationRetryAttemptsForTesting() const { return initialization_retry_attempts_; }
+  bool participatesInWorkerInitialization() const {
+    return initialization_role_ == PluginInitializationRole::RequestWorker;
+  }
+  void setRecoveryVmKeyForTesting(std::string vm_key) {
+    recovery_vm_key_for_testing_ = std::move(vm_key);
+  }
+  void recordFailOpenSkip();
 #else
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject {
 public:
@@ -228,12 +269,24 @@ public:
 private:
 #if defined(HIGRESS)
   void initializeReclaimTimer();
+  void recordInitializationFailure();
+  void leaveUninitialized();
   void onReclaimTimer();
   bool syncHandleToCurrentGeneration(const std::string& vm_key);
   PluginSharedPtr plugin_;
   WasmHandleSharedPtr base_wasm_;
+  Event::Dispatcher* dispatcher_{nullptr};
+  WorkerInitStatsHandlerSharedPtr worker_init_stats_;
+  ThreadLocalPluginResultFactory retry_factory_;
   Event::TimerPtr reclaim_timer_;
   bool reclaim_timer_enabled_;
+  PluginInitializationState initialization_state_{PluginInitializationState::Ready};
+  proxy_wasm::FailState last_initialization_failure_{proxy_wasm::FailState::Ok};
+  bool initialization_failure_retryable_{false};
+  bool counted_uninitialized_{false};
+  uint64_t initialization_retry_attempts_{0};
+  PluginInitializationRole initialization_role_{PluginInitializationRole::RequestWorker};
+  std::string recovery_vm_key_for_testing_;
   static constexpr std::chrono::milliseconds kReclaimTimerInterval{1000};
 #endif
   PluginHandleSharedPtr handle_;
@@ -263,10 +316,18 @@ getOrCreateThreadLocalPlugin(const WasmHandleSharedPtr& base_wasm, const PluginS
                              Event::Dispatcher& dispatcher,
                              CreateContextFn create_root_context_for_testing = nullptr);
 
+#if defined(HIGRESS)
+ThreadLocalPluginResult
+getOrCreateThreadLocalPluginWithResult(const WasmHandleSharedPtr& base_wasm,
+                                       const PluginSharedPtr& plugin, Event::Dispatcher& dispatcher,
+                                       CreateContextFn create_root_context_for_testing = nullptr);
+#endif
+
 void clearCodeCacheForTesting();
 void setTimeOffsetForCodeCacheForTesting(MonotonicTime::duration d);
 #if defined(HIGRESS)
 size_t rebuildGuardRegistrySizeForTesting();
+bool acquireRecoveryPermitForTesting(absl::string_view vm_key, Event::Dispatcher& dispatcher);
 #endif
 WasmEvent toWasmEvent(const std::shared_ptr<WasmHandleBase>& wasm);
 

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -11,17 +11,36 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
           context.threadLocal())) {
   const auto plugin = std::make_shared<Common::Wasm::Plugin>(
       config.config(), context.direction(), context.localInfo(), &context.listenerMetadata());
+#if defined(HIGRESS)
+  auto scope = context.scope().createScope("");
+  auto worker_init_stats = std::make_shared<Common::Wasm::WorkerInitStatsHandler>(
+      scope, config.config().vm_config().runtime(), plugin->name_);
+  auto* main_thread_dispatcher = &context.mainThreadDispatcher();
+#endif
 
-  auto callback = [plugin, this](const Common::Wasm::WasmHandleSharedPtr& base_wasm) {
+  auto callback = [plugin, this
+#if defined(HIGRESS)
+                   ,
+                   worker_init_stats, main_thread_dispatcher
+#endif
+  ](const Common::Wasm::WasmHandleSharedPtr& base_wasm) {
 #if defined(HIGRESS)
     base_wasm_handle_ = base_wasm;
 #endif
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
-    tls_slot_->set([base_wasm, plugin](Event::Dispatcher& dispatcher) {
+    tls_slot_->set([base_wasm, plugin
+#if defined(HIGRESS)
+                    ,
+                    worker_init_stats, main_thread_dispatcher
+#endif
+    ](Event::Dispatcher& dispatcher) {
 #if defined(HIGRESS)
       return std::make_shared<PluginHandleSharedPtrThreadLocal>(
-          Common::Wasm::getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher), base_wasm,
-          true);
+          Common::Wasm::getOrCreateThreadLocalPluginWithResult(base_wasm, plugin, dispatcher),
+          plugin, base_wasm, dispatcher, worker_init_stats, true, nullptr,
+          &dispatcher == main_thread_dispatcher
+              ? Common::Wasm::PluginInitializationRole::MainThread
+              : Common::Wasm::PluginInitializationRole::RequestWorker);
 #else
       return std::make_shared<PluginHandleSharedPtrThreadLocal>(
           Common::Wasm::getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher));
@@ -31,10 +50,10 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
 
   bool created = false;
 #if defined(HIGRESS)
-  created = Common::Wasm::createWasm(
-      plugin, context.scope().createScope(""), context.clusterManager(), context.initManager(),
-      context.mainThreadDispatcher(), context.api(), context.lifecycleNotifier(),
-      remote_data_provider_, std::move(callback), nullptr, &context.runtime());
+  created = Common::Wasm::createWasm(plugin, scope, context.clusterManager(), context.initManager(),
+                                     context.mainThreadDispatcher(), context.api(),
+                                     context.lifecycleNotifier(), remote_data_provider_,
+                                     std::move(callback), nullptr, &context.runtime());
 #else
   created = Common::Wasm::createWasm(
       plugin, context.scope().createScope(""), context.clusterManager(), context.initManager(),

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -21,6 +21,22 @@ using Envoy::Extensions::Common::Wasm::PluginHandleSharedPtrThreadLocal;
 using Envoy::Extensions::Common::Wasm::PluginSharedPtr;
 using Envoy::Extensions::Common::Wasm::Wasm;
 
+#if defined(HIGRESS)
+class UninitializedFailClosedContext final : public Context {
+public:
+  using Context::Context;
+
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
+    failStream(proxy_wasm::WasmStreamType::Request);
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
+    return Http::FilterHeadersStatus::Continue;
+  }
+};
+#endif
+
 class FilterConfig : Logger::Loggable<Logger::Id::wasm> {
 public:
   FilterConfig(const envoy::extensions::filters::http::wasm::v3::Wasm& config,
@@ -35,7 +51,25 @@ public:
     if (!opt_ref) {
       return nullptr;
     }
+#if defined(HIGRESS)
     PluginHandleSharedPtr handle = opt_ref->handle();
+    if (opt_ref->initializationState() ==
+        Envoy::Extensions::Common::Wasm::PluginInitializationState::Uninitialized) {
+      const auto recovery = opt_ref->tryInitialize();
+      if (recovery.status ==
+          Envoy::Extensions::Common::Wasm::PluginInitializationRecoveryStatus::Recovered) {
+        handle = opt_ref->handle();
+      } else if (handle != nullptr && handle->plugin()->fail_open_) {
+        opt_ref->recordFailOpenSkip();
+        return nullptr;
+      } else if (handle != nullptr) {
+        return std::make_shared<UninitializedFailClosedContext>(nullptr, 0, handle);
+      }
+    }
+#endif
+#if !defined(HIGRESS)
+    PluginHandleSharedPtr handle = opt_ref->handle();
+#endif
     if (!handle) {
       return nullptr;
     }

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -1,3 +1,10 @@
+#if defined(HIGRESS)
+#include <thread>
+
+#include "source/common/common/cleanup.h"
+
+#endif
+
 #include "envoy/server/lifecycle_notifier.h"
 
 #include "source/common/common/hex.h"
@@ -25,6 +32,7 @@
 using Envoy::Server::ServerLifecycleNotifier;
 using StageCallbackWithCompletion =
     Envoy::Server::ServerLifecycleNotifier::StageCallbackWithCompletion;
+using testing::_;
 using testing::Eq;
 using testing::Return;
 
@@ -92,6 +100,499 @@ INSTANTIATE_TEST_SUITE_P(Runtimes, WasmCommonTest,
                          Envoy::Extensions::Common::Wasm::runtime_and_cpp_values,
                          Envoy::Extensions::Common::Wasm::wasmTestParamsToString);
 
+#if defined(HIGRESS)
+TEST(WasmWorkerInitStatsTest, TracksInitialFailureSkipAndWrapperLifetime) {
+  Stats::IsolatedStoreImpl stats_store;
+  auto scope = Stats::ScopeSharedPtr(stats_store.createScope(""));
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+
+  envoy::extensions::wasm::v3::PluginConfig fail_open_config;
+  fail_open_config.set_name("worker_init_test");
+  fail_open_config.set_fail_open(true);
+  auto fail_open_plugin = std::make_shared<Plugin>(
+      fail_open_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
+      nullptr);
+
+  auto stats = std::make_shared<WorkerInitStatsHandler>(scope, "envoy.wasm.runtime.v8",
+                                                        fail_open_plugin->name_);
+  const std::string prefix = "wasm.envoy.wasm.runtime.v8.plugin.worker_init_test.";
+  auto& retryable_failure =
+      scope->counterFromString(prefix + "worker_init_retryable_failure_total");
+  auto& terminal_failure = scope->counterFromString(prefix + "worker_init_terminal_failure_total");
+  auto& retry_total = scope->counterFromString(prefix + "worker_init_retry_total");
+  auto& recovered_total = scope->counterFromString(prefix + "worker_init_recovered_total");
+  auto& fail_open_skip = scope->counterFromString(prefix + "worker_fail_open_skip_total");
+  auto& uninitialized = scope->gaugeFromString(prefix + "worker_uninitialized",
+                                               Stats::Gauge::ImportMode::NeverImport);
+  NiceMock<Event::MockDispatcher> dispatcher;
+
+  {
+    PluginHandleSharedPtrThreadLocal retryable(
+        ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::UnableToCloneVm}, fail_open_plugin,
+        nullptr, dispatcher, stats);
+    EXPECT_EQ(PluginInitializationState::Uninitialized, retryable.initializationState());
+    EXPECT_EQ(proxy_wasm::FailState::UnableToCloneVm, retryable.lastInitializationFailure());
+    EXPECT_TRUE(retryable.initializationFailureRetryable());
+    ASSERT_NE(nullptr, retryable.handle());
+    EXPECT_EQ(nullptr, retryable.handle()->wasmHandle());
+    EXPECT_EQ(1, retryable_failure.value());
+    EXPECT_EQ(0, terminal_failure.value());
+    EXPECT_EQ(1, uninitialized.value());
+
+    retryable.recordFailOpenSkip();
+    EXPECT_EQ(1, fail_open_skip.value());
+
+    envoy::extensions::wasm::v3::PluginConfig fail_closed_config = fail_open_config;
+    fail_closed_config.set_fail_open(false);
+    auto fail_closed_plugin = std::make_shared<Plugin>(
+        fail_closed_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
+        nullptr);
+    {
+      PluginHandleSharedPtrThreadLocal terminal(
+          ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::ConfigureFailed},
+          fail_closed_plugin, nullptr, dispatcher, stats);
+      EXPECT_FALSE(terminal.initializationFailureRetryable());
+      terminal.recordFailOpenSkip();
+      EXPECT_EQ(1, terminal_failure.value());
+      EXPECT_EQ(1, fail_open_skip.value());
+      EXPECT_EQ(2, uninitialized.value());
+    }
+    EXPECT_EQ(1, uninitialized.value());
+  }
+
+  EXPECT_EQ(0, uninitialized.value());
+  EXPECT_EQ(0, retry_total.value());
+  EXPECT_EQ(0, recovered_total.value());
+
+  envoy::extensions::wasm::v3::PluginConfig base_failure_config = fail_open_config;
+  base_failure_config.set_fail_open(false);
+  auto base_failure_plugin = std::make_shared<Plugin>(
+      base_failure_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info,
+      nullptr);
+  auto base_failure =
+      getOrCreateThreadLocalPluginWithResult(nullptr, base_failure_plugin, dispatcher);
+  ASSERT_NE(nullptr, base_failure.handle);
+  EXPECT_EQ(proxy_wasm::FailState::Ok, base_failure.fail_state);
+  PluginHandleSharedPtrThreadLocal ready(std::move(base_failure), base_failure_plugin, nullptr,
+                                         dispatcher, stats);
+  EXPECT_EQ(PluginInitializationState::Ready, ready.initializationState());
+  EXPECT_EQ(0, uninitialized.value());
+}
+
+class WasmWorkerInitializationRetryTest : public testing::Test {
+protected:
+  void SetUp() override {
+    clearCodeCacheForTesting();
+    envoy::extensions::wasm::v3::PluginConfig config;
+    config.set_name("worker_init_retry_test");
+    config.set_fail_open(true);
+    plugin_ = std::make_shared<Plugin>(
+        config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info_, nullptr);
+    stats_ =
+        std::make_shared<WorkerInitStatsHandler>(scope_, "envoy.wasm.runtime.v8", plugin_->name_);
+  }
+
+  void advanceRecoveryTime(std::chrono::milliseconds duration) {
+    recovery_time_offset_ += duration;
+    setTimeOffsetForCodeCacheForTesting(recovery_time_offset_);
+  }
+
+  std::unique_ptr<PluginHandleSharedPtrThreadLocal>
+  makeRetryableWrapper(absl::string_view vm_key, ThreadLocalPluginResultFactory factory) {
+    auto wrapper = std::make_unique<PluginHandleSharedPtrThreadLocal>(
+        ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError}, plugin_, nullptr,
+        dispatcher_, stats_, false, std::move(factory));
+    wrapper->setRecoveryVmKeyForTesting(std::string(vm_key));
+    return wrapper;
+  }
+
+  Stats::Counter& counter(absl::string_view name) {
+    return scope_->counterFromString(
+        absl::StrCat("wasm.envoy.wasm.runtime.v8.plugin.worker_init_retry_test.", name));
+  }
+
+  Stats::Gauge& uninitializedGauge() {
+    return scope_->gaugeFromString(
+        "wasm.envoy.wasm.runtime.v8.plugin.worker_init_retry_test.worker_uninitialized",
+        Stats::Gauge::ImportMode::NeverImport);
+  }
+
+  Stats::IsolatedStoreImpl stats_store_;
+  Stats::ScopeSharedPtr scope_{stats_store_.createScope("")};
+  NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  PluginSharedPtr plugin_;
+  WorkerInitStatsHandlerSharedPtr stats_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  MonotonicTime::duration recovery_time_offset_{};
+};
+
+TEST_F(WasmWorkerInitializationRetryTest, PersistentFailureUsesRequestOnlyFixedGuardWithoutCap) {
+  uint64_t factory_calls = 0;
+  auto wrapper = makeRetryableWrapper("persistent-key", [&factory_calls]() {
+    ++factory_calls;
+    return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError};
+  });
+
+  const auto first = wrapper->tryInitialize();
+  EXPECT_EQ(PluginInitializationRecoveryStatus::RetryableFailure, first.status);
+  EXPECT_EQ(1, factory_calls);
+  const auto cooling_down = wrapper->tryInitialize();
+  EXPECT_EQ(PluginInitializationRecoveryStatus::CoolingDown, cooling_down.status);
+  EXPECT_GT(cooling_down.remaining_cooldown.count(), 0);
+  EXPECT_LE(cooling_down.remaining_cooldown, std::chrono::seconds(1));
+  EXPECT_EQ(1, factory_calls);
+
+  for (uint64_t attempt = 2; attempt <= 7; ++attempt) {
+    advanceRecoveryTime(std::chrono::seconds(1));
+    EXPECT_EQ(PluginInitializationRecoveryStatus::RetryableFailure,
+              wrapper->tryInitialize().status);
+    EXPECT_EQ(attempt, factory_calls);
+  }
+
+  EXPECT_EQ(7, wrapper->initializationRetryAttemptsForTesting());
+  EXPECT_EQ(PluginInitializationState::Uninitialized, wrapper->initializationState());
+  EXPECT_TRUE(wrapper->initializationFailureRetryable());
+  EXPECT_EQ(8, counter("worker_init_retryable_failure_total").value());
+  EXPECT_EQ(7, counter("worker_init_retry_total").value());
+  EXPECT_EQ(0, counter("worker_init_recovered_total").value());
+  EXPECT_EQ(1, uninitializedGauge().value());
+
+  advanceRecoveryTime(std::chrono::seconds(32));
+  EXPECT_EQ(7, factory_calls);
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, IdleDoesNotAttemptAndFirstRequestRecoversImmediately) {
+  uint64_t factory_calls = 0;
+  auto wrapper = makeRetryableWrapper("idle-key", [this, &factory_calls]() {
+    ++factory_calls;
+    return ThreadLocalPluginResult{std::make_shared<PluginHandle>(nullptr, plugin_),
+                                   proxy_wasm::FailState::Ok};
+  });
+
+  advanceRecoveryTime(std::chrono::seconds(10));
+  EXPECT_EQ(0, factory_calls);
+  EXPECT_EQ(0, counter("worker_init_retry_total").value());
+  EXPECT_EQ(PluginInitializationState::Uninitialized, wrapper->initializationState());
+  EXPECT_EQ(1, uninitializedGauge().value());
+
+  EXPECT_EQ(PluginInitializationRecoveryStatus::Recovered, wrapper->tryInitialize().status);
+  EXPECT_EQ(1, factory_calls);
+  EXPECT_EQ(PluginInitializationState::Ready, wrapper->initializationState());
+  EXPECT_EQ(proxy_wasm::FailState::Ok, wrapper->lastInitializationFailure());
+  EXPECT_FALSE(wrapper->initializationFailureRetryable());
+  EXPECT_EQ(0, uninitializedGauge().value());
+  EXPECT_EQ(1, counter("worker_init_retry_total").value());
+  EXPECT_EQ(1, counter("worker_init_recovered_total").value());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, MainThreadFailureIsNeutralAndNeverRecovers) {
+  uint64_t factory_calls = 0;
+  auto wrapper = std::make_unique<PluginHandleSharedPtrThreadLocal>(
+      ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError}, plugin_, nullptr,
+      dispatcher_, stats_, false,
+      [&factory_calls]() {
+        ++factory_calls;
+        return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError};
+      },
+      PluginInitializationRole::MainThread);
+
+  EXPECT_FALSE(wrapper->participatesInWorkerInitialization());
+  EXPECT_EQ(PluginInitializationState::Ready, wrapper->initializationState());
+  EXPECT_FALSE(wrapper->initializationFailureRetryable());
+  ASSERT_NE(nullptr, wrapper->handle());
+  EXPECT_EQ(nullptr, wrapper->handle()->wasmHandle());
+  EXPECT_EQ(0, counter("worker_init_retryable_failure_total").value());
+  EXPECT_EQ(0, counter("worker_init_terminal_failure_total").value());
+  EXPECT_EQ(0, counter("worker_init_retry_total").value());
+  EXPECT_EQ(0, counter("worker_init_recovered_total").value());
+  EXPECT_EQ(0, uninitializedGauge().value());
+  EXPECT_EQ(0, rebuildGuardRegistrySizeForTesting());
+
+  advanceRecoveryTime(std::chrono::seconds(10));
+  EXPECT_EQ(PluginInitializationRecoveryStatus::TerminalFailure, wrapper->tryInitialize().status);
+  EXPECT_EQ(0, factory_calls);
+  EXPECT_EQ(0, rebuildGuardRegistrySizeForTesting());
+  wrapper->recordFailOpenSkip();
+  EXPECT_EQ(0, counter("worker_fail_open_skip_total").value());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, MainThreadSuccessPreservesReadyHandleOwnership) {
+  auto handle = std::make_shared<PluginHandle>(nullptr, plugin_);
+  PluginHandleSharedPtrThreadLocal wrapper(
+      ThreadLocalPluginResult{handle, proxy_wasm::FailState::Ok}, plugin_, nullptr, dispatcher_,
+      stats_, false, nullptr, PluginInitializationRole::MainThread);
+
+  EXPECT_FALSE(wrapper.participatesInWorkerInitialization());
+  EXPECT_EQ(PluginInitializationState::Ready, wrapper.initializationState());
+  EXPECT_EQ(handle, wrapper.handle());
+  EXPECT_EQ(0, uninitializedGauge().value());
+  EXPECT_EQ(0, counter("worker_init_retryable_failure_total").value());
+  EXPECT_EQ(0, counter("worker_init_terminal_failure_total").value());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, FourRequestWorkersCountAndRecoverIndependently) {
+  constexpr uint64_t worker_count = 4;
+  std::vector<uint64_t> factory_calls(worker_count, 0);
+  std::vector<std::unique_ptr<PluginHandleSharedPtrThreadLocal>> wrappers;
+  wrappers.reserve(worker_count);
+  for (uint64_t worker = 0; worker < worker_count; ++worker) {
+    wrappers.push_back(makeRetryableWrapper(
+        absl::StrCat("request-worker-", worker), [this, &factory_calls, worker]() {
+          ++factory_calls[worker];
+          return ThreadLocalPluginResult{std::make_shared<PluginHandle>(nullptr, plugin_),
+                                         proxy_wasm::FailState::Ok};
+        }));
+  }
+
+  EXPECT_EQ(worker_count, counter("worker_init_retryable_failure_total").value());
+  EXPECT_EQ(worker_count, uninitializedGauge().value());
+  for (uint64_t worker = 0; worker < worker_count; ++worker) {
+    EXPECT_TRUE(wrappers[worker]->participatesInWorkerInitialization());
+    EXPECT_EQ(PluginInitializationRecoveryStatus::Recovered,
+              wrappers[worker]->tryInitialize().status);
+    EXPECT_EQ(1, factory_calls[worker]);
+  }
+  EXPECT_EQ(worker_count, counter("worker_init_retry_total").value());
+  EXPECT_EQ(worker_count, counter("worker_init_recovered_total").value());
+  EXPECT_EQ(0, uninitializedGauge().value());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, LatestRetryReasonCanBecomeTerminal) {
+  uint64_t factory_calls = 0;
+  auto wrapper = makeRetryableWrapper("terminal-key", [&factory_calls]() {
+    ++factory_calls;
+    return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::ConfigureFailed};
+  });
+
+  EXPECT_EQ(PluginInitializationRecoveryStatus::TerminalFailure, wrapper->tryInitialize().status);
+  EXPECT_EQ(PluginInitializationState::Uninitialized, wrapper->initializationState());
+  EXPECT_EQ(proxy_wasm::FailState::ConfigureFailed, wrapper->lastInitializationFailure());
+  EXPECT_FALSE(wrapper->initializationFailureRetryable());
+  EXPECT_EQ(1, counter("worker_init_retryable_failure_total").value());
+  EXPECT_EQ(1, counter("worker_init_terminal_failure_total").value());
+  EXPECT_EQ(1, counter("worker_init_retry_total").value());
+  EXPECT_EQ(1, factory_calls);
+
+  advanceRecoveryTime(std::chrono::seconds(10));
+  EXPECT_EQ(PluginInitializationRecoveryStatus::TerminalFailure, wrapper->tryInitialize().status);
+  EXPECT_EQ(1, factory_calls);
+  EXPECT_EQ(1, counter("worker_init_terminal_failure_total").value());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, RetryAllowlistIsTerminalByDefault) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(dispatcher, createTimer_(_)).Times(0);
+  for (const auto state :
+       {proxy_wasm::FailState::UnableToCreateVm, proxy_wasm::FailState::UnableToCloneVm,
+        proxy_wasm::FailState::UnableToInitializeCode, proxy_wasm::FailState::RuntimeError}) {
+    PluginHandleSharedPtrThreadLocal wrapper(ThreadLocalPluginResult{nullptr, state}, plugin_,
+                                             nullptr, dispatcher, nullptr);
+    EXPECT_TRUE(wrapper.initializationFailureRetryable());
+    EXPECT_EQ(0, wrapper.initializationRetryAttemptsForTesting());
+  }
+
+  for (const auto state :
+       {proxy_wasm::FailState::StartFailed, proxy_wasm::FailState::ConfigureFailed,
+        proxy_wasm::FailState::MissingFunction, proxy_wasm::FailState::RecoverError,
+        static_cast<proxy_wasm::FailState>(999)}) {
+    PluginHandleSharedPtrThreadLocal wrapper(ThreadLocalPluginResult{nullptr, state}, plugin_,
+                                             nullptr, dispatcher, nullptr);
+    EXPECT_FALSE(wrapper.initializationFailureRetryable());
+    EXPECT_EQ(0, wrapper.initializationRetryAttemptsForTesting());
+  }
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, ReplacementOwnsStateButSharesVmKeyGuard) {
+  uint64_t old_factory_calls = 0;
+  auto old_wrapper = makeRetryableWrapper("shared-key", [&old_factory_calls]() {
+    ++old_factory_calls;
+    return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError};
+  });
+  EXPECT_EQ(1, uninitializedGauge().value());
+  EXPECT_EQ(PluginInitializationRecoveryStatus::RetryableFailure,
+            old_wrapper->tryInitialize().status);
+  EXPECT_EQ(1, old_factory_calls);
+  old_wrapper.reset();
+  EXPECT_EQ(0, uninitializedGauge().value());
+
+  uint64_t new_factory_calls = 0;
+  auto new_wrapper = makeRetryableWrapper("shared-key", [&new_factory_calls]() {
+    ++new_factory_calls;
+    return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError};
+  });
+  EXPECT_EQ(0, new_wrapper->initializationRetryAttemptsForTesting());
+  EXPECT_EQ(1, uninitializedGauge().value());
+  EXPECT_EQ(PluginInitializationRecoveryStatus::CoolingDown, new_wrapper->tryInitialize().status);
+  EXPECT_EQ(0, new_factory_calls);
+
+  uint64_t different_factory_calls = 0;
+  auto different_wrapper = makeRetryableWrapper("different-key", [&different_factory_calls]() {
+    ++different_factory_calls;
+    return ThreadLocalPluginResult{nullptr, proxy_wasm::FailState::RuntimeError};
+  });
+  EXPECT_EQ(PluginInitializationRecoveryStatus::RetryableFailure,
+            different_wrapper->tryInitialize().status);
+  EXPECT_EQ(1, different_factory_calls);
+
+  advanceRecoveryTime(std::chrono::seconds(1));
+  EXPECT_EQ(PluginInitializationRecoveryStatus::RetryableFailure,
+            new_wrapper->tryInitialize().status);
+  EXPECT_EQ(1, new_factory_calls);
+  EXPECT_EQ(1, new_wrapper->initializationRetryAttemptsForTesting());
+}
+
+TEST_F(WasmWorkerInitializationRetryTest, GuardFirstAttemptAtEpochAndCrossKeySweep) {
+  EXPECT_TRUE(acquireRecoveryPermitForTesting("key-a", dispatcher_));
+  EXPECT_FALSE(acquireRecoveryPermitForTesting("key-a", dispatcher_));
+  EXPECT_TRUE(acquireRecoveryPermitForTesting("key-b", dispatcher_));
+  EXPECT_EQ(2, rebuildGuardRegistrySizeForTesting());
+
+  advanceRecoveryTime(std::chrono::seconds(1));
+  EXPECT_TRUE(acquireRecoveryPermitForTesting("key-c", dispatcher_));
+  EXPECT_EQ(1, rebuildGuardRegistrySizeForTesting());
+}
+
+TEST_P(WasmCommonTest, BaseWasmHandleDeletionUsesOwningDispatcher) {
+  Stats::IsolatedStoreImpl stats_store;
+  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
+  NiceMock<Event::MockDispatcher> dispatcher("main_thread");
+  NiceMock<Runtime::MockLoader> runtime;
+  Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
+  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+
+  envoy::extensions::wasm::v3::PluginConfig plugin_config;
+  plugin_config.set_name("base_wasm_owner_dispatcher");
+  auto* vm_config = plugin_config.mutable_vm_config();
+  vm_config->set_vm_id("base_wasm_owner_dispatcher");
+  vm_config->set_runtime(absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())));
+  const std::string code =
+      std::get<0>(GetParam()) == "null"
+          ? "CommonWasmTestCpp"
+          : TestEnvironment::readFileToStringForTest(
+                TestEnvironment::substitute("{{ test_rundir }}/test/extensions/common/wasm/"
+                                            "test_data/test_cpp.wasm"));
+  ASSERT_FALSE(code.empty());
+  vm_config->mutable_code()->mutable_local()->set_inline_bytes(code);
+  auto plugin = std::make_shared<Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
+
+  WasmHandleSharedPtr base_wasm;
+  ASSERT_TRUE(createWasm(
+      plugin, scope, cluster_manager, init_manager, dispatcher, *api, lifecycle_notifier,
+      remote_data_provider, [&base_wasm](const WasmHandleSharedPtr& handle) { base_wasm = handle; },
+      nullptr, &runtime));
+  ASSERT_NE(base_wasm, nullptr);
+  std::weak_ptr<proxy_wasm::WasmBase> weak_wasm = base_wasm->wasm();
+
+  Event::DispatcherThreadDeletableConstPtr pending_deletion;
+  EXPECT_CALL(dispatcher, deleteInDispatcherThread(_))
+      .WillOnce(Invoke([&pending_deletion](Event::DispatcherThreadDeletableConstPtr deletable) {
+        pending_deletion = std::move(deletable);
+      }));
+
+  std::thread worker([base_wasm = std::move(base_wasm)]() mutable { base_wasm.reset(); });
+  worker.join();
+
+  EXPECT_FALSE(weak_wasm.expired());
+  ASSERT_NE(pending_deletion, nullptr);
+  pending_deletion.reset();
+  EXPECT_TRUE(weak_wasm.expired());
+}
+
+TEST_P(WasmCommonTest, WorkerCloneFailureDoesNotPoisonBaseOrNackNextSameVmKeyConfig) {
+  proxy_wasm::clearWasmCachesForTesting();
+  clearCodeCacheForTesting();
+  Cleanup cleanup([]() {
+    proxy_wasm::clearWasmCachesForTesting();
+    clearCodeCacheForTesting();
+  });
+
+  Stats::IsolatedStoreImpl stats_store;
+  Api::ApiPtr api = Api::createApiForTest(stats_store);
+  NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_worker_clone_failure_test"));
+  NiceMock<Runtime::MockLoader> runtime;
+  Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
+  auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+
+  envoy::extensions::wasm::v3::PluginConfig plugin_config;
+  plugin_config.set_name("worker_clone_failure_isolation");
+  auto* vm_config = plugin_config.mutable_vm_config();
+  vm_config->set_vm_id("worker_clone_failure_isolation");
+  vm_config->set_runtime(absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam())));
+  const std::string code =
+      std::get<0>(GetParam()) == "null"
+          ? "CommonWasmTestCpp"
+          : TestEnvironment::readFileToStringForTest(
+                TestEnvironment::substitute("{{ test_rundir }}/test/extensions/common/wasm/"
+                                            "test_data/test_cpp.wasm"));
+  ASSERT_FALSE(code.empty());
+  vm_config->mutable_code()->mutable_local()->set_inline_bytes(code);
+  auto plugin = std::make_shared<Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
+
+  WasmHandleSharedPtr healthy_base;
+  EXPECT_TRUE(createWasm(
+      plugin, scope, cluster_manager, init_manager, *dispatcher, *api, lifecycle_notifier,
+      remote_data_provider,
+      [&healthy_base](const WasmHandleSharedPtr& handle) { healthy_base = handle; }, nullptr,
+      &runtime));
+  ASSERT_NE(nullptr, healthy_base);
+  ASSERT_NE(nullptr, healthy_base->wasm());
+  const std::string vm_key(healthy_base->wasm()->vm_key());
+
+  uint32_t clone_invocations = 0;
+  const auto clone_factory =
+      [&clone_invocations](const WasmHandleBaseSharedPtr&) -> WasmHandleBaseSharedPtr {
+    ++clone_invocations;
+    return nullptr;
+  };
+  const auto plugin_factory =
+      [](const WasmHandleBaseSharedPtr& wasm_handle,
+         const PluginBaseSharedPtr& plugin_handle) -> PluginHandleBaseSharedPtr {
+    return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(wasm_handle),
+                                          std::static_pointer_cast<Plugin>(plugin_handle));
+  };
+  const auto worker_failure = proxy_wasm::getOrCreateThreadLocalPluginWithResult(
+      std::static_pointer_cast<proxy_wasm::WasmHandleBase>(healthy_base), plugin, clone_factory,
+      plugin_factory);
+  EXPECT_EQ(nullptr, worker_failure.handle);
+  EXPECT_EQ(proxy_wasm::FailState::UnableToCloneVm, worker_failure.fail_state);
+  EXPECT_EQ(1U, clone_invocations);
+  EXPECT_EQ(proxy_wasm::FailState::Ok, healthy_base->wasm()->fail_state());
+  EXPECT_FALSE(healthy_base->wasm()->isFailed());
+  EXPECT_EQ(nullptr, proxy_wasm::getThreadLocalWasm(vm_key));
+
+  WasmHandleSharedPtr same_key_base;
+  EXPECT_TRUE(createWasm(
+      plugin, scope, cluster_manager, init_manager, *dispatcher, *api, lifecycle_notifier,
+      remote_data_provider,
+      [&same_key_base](const WasmHandleSharedPtr& handle) { same_key_base = handle; }, nullptr,
+      &runtime));
+  EXPECT_NE(nullptr, same_key_base);
+  EXPECT_EQ(healthy_base, same_key_base);
+
+  // A second real Host worker entry must invoke clone again. If the failed worker had
+  // polluted the thread-local cache, this factory would not be called a second time.
+  const auto repeated_worker_failure = proxy_wasm::getOrCreateThreadLocalPluginWithResult(
+      std::static_pointer_cast<proxy_wasm::WasmHandleBase>(same_key_base), plugin, clone_factory,
+      plugin_factory);
+  EXPECT_EQ(nullptr, repeated_worker_failure.handle);
+  EXPECT_EQ(proxy_wasm::FailState::UnableToCloneVm, repeated_worker_failure.fail_state);
+  EXPECT_EQ(2U, clone_invocations);
+  EXPECT_EQ(proxy_wasm::FailState::Ok, healthy_base->wasm()->fail_state());
+  EXPECT_FALSE(healthy_base->wasm()->isFailed());
+  EXPECT_EQ(nullptr, proxy_wasm::getThreadLocalWasm(vm_key));
+}
+#endif
+
 TEST_P(WasmCommonTest, WasmFailState) {
   Stats::IsolatedStoreImpl stats_store;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
@@ -105,8 +606,8 @@ TEST_P(WasmCommonTest, WasmFailState) {
       plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
 #ifdef HIGRESS
   // auto wasm = std::make_shared<WasmHandle>(
-  //     std::make_unique<Wasm>(plugin->wasmConfig(), "", scope, *api, cluster_manager, *dispatcher),
-  //     *dispatcher);
+  //     std::make_unique<Wasm>(plugin->wasmConfig(), "", scope, *api, cluster_manager,
+  //     *dispatcher), *dispatcher);
   auto wasm = std::make_shared<WasmHandle>(
       std::make_unique<Wasm>(plugin->wasmConfig(), "", scope, *api, cluster_manager, *dispatcher));
 #else
@@ -841,7 +1342,7 @@ TEST_P(WasmCommonTest, RemoteCode) {
             });
 #ifdef HIGRESS
         return std::make_shared<WasmHandle>(wasm);
-        // return std::make_shared<WasmHandle>(wasm, *dispatcher);
+    // return std::make_shared<WasmHandle>(wasm, *dispatcher);
 #else
         return std::make_shared<WasmHandle>(wasm);
 #endif
@@ -967,7 +1468,7 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
             });
 #ifdef HIGRESS
         return std::make_shared<WasmHandle>(wasm);
-        // return std::make_shared<WasmHandle>(wasm, *dispatcher);
+    // return std::make_shared<WasmHandle>(wasm, *dispatcher);
 #else
         return std::make_shared<WasmHandle>(wasm);
 #endif

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -47,10 +47,15 @@ protected:
   void initializeForRemote() {
     retry_timer_ = new Event::MockTimer();
 
-    EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb timer_cb) {
-      retry_timer_cb_ = timer_cb;
-      return retry_timer_;
-    }));
+    EXPECT_CALL(dispatcher_, createTimer_(_))
+        .WillOnce(Invoke([this](Event::TimerCb timer_cb) {
+          retry_timer_cb_ = timer_cb;
+          return retry_timer_;
+        }))
+        // The Host canary clone initializes its own runtime-stats timer after the remote retry
+        // timer. Keep this fixture focused on retaining the retry callback while accepting those
+        // worker-local timers.
+        .WillRepeatedly(testing::ReturnNew<NiceMock<Event::MockTimer>>());
   }
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
@@ -951,6 +956,52 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmCreateFilter) {
   EXPECT_NE(filter_config->createFilter(), nullptr);
 }
 
+#if defined(HIGRESS)
+TEST_P(WasmFilterConfigTest, MainThreadTlsSlotUsesNeutralRoleOnHealthyPath) {
+  NiceMock<Envoy::ThreadLocal::MockInstance> threadlocal;
+  const std::string yaml = TestEnvironment::substitute(absl::StrCat(R"EOF(
+  config:
+    name: main_role_test
+    vm_config:
+      runtime: "envoy.wasm.runtime.)EOF",
+                                                                    std::get<0>(GetParam()), R"EOF("
+      configuration:
+         "@type": "type.googleapis.com/google.protobuf.StringValue"
+         value: "some configuration"
+      code:
+        local:
+          filename: "{{ test_rundir }}/test/extensions/filters/http/wasm/test_data/test_cpp.wasm"
+  )EOF"));
+
+  envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+  EXPECT_CALL(context_, threadLocal()).WillOnce(ReturnRef(threadlocal));
+  EXPECT_CALL(context_, mainThreadDispatcher()).WillRepeatedly(ReturnRef(threadlocal.dispatcher_));
+  auto filter_config = std::make_unique<FilterConfig>(proto_config, context_);
+  ASSERT_EQ(threadlocal.current_slot_, 1);
+  auto wrapper = std::dynamic_pointer_cast<PluginHandleSharedPtrThreadLocal>(threadlocal.data_[0]);
+  ASSERT_NE(wrapper, nullptr);
+  EXPECT_FALSE(wrapper->participatesInWorkerInitialization());
+  EXPECT_EQ(Envoy::Extensions::Common::Wasm::PluginInitializationState::Ready,
+            wrapper->initializationState());
+  EXPECT_NE(wrapper->handle(), nullptr);
+  EXPECT_NE(wrapper->handle()->wasmHandle(), nullptr);
+
+  const std::string stats_prefix =
+      absl::StrCat("wasm.", proto_config.config().vm_config().runtime(), ".plugin.main_role_test.");
+  EXPECT_EQ(
+      0,
+      stats_scope_.counterFromString(stats_prefix + "worker_init_retryable_failure_total").value());
+  EXPECT_EQ(
+      0,
+      stats_scope_.counterFromString(stats_prefix + "worker_init_terminal_failure_total").value());
+  EXPECT_EQ(0, stats_scope_
+                   .gaugeFromString(stats_prefix + "worker_uninitialized",
+                                    Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+}
+#endif
+
 TEST_P(WasmFilterConfigTest, FailedToGetThreadLocalPlugin) {
   NiceMock<Envoy::ThreadLocal::MockInstance> threadlocal;
   const std::string yaml = TestEnvironment::substitute(absl::StrCat(R"EOF(
@@ -969,15 +1020,140 @@ TEST_P(WasmFilterConfigTest, FailedToGetThreadLocalPlugin) {
 
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromYaml(yaml, proto_config);
+#if defined(HIGRESS)
+  proto_config.mutable_config()->set_name("worker_init_test");
+#endif
   EXPECT_CALL(context_, threadLocal()).WillOnce(ReturnRef(threadlocal));
   threadlocal.registered_ = true;
   auto filter_config = std::make_unique<FilterConfig>(proto_config, context_);
   ASSERT_EQ(threadlocal.current_slot_, 1);
   ASSERT_NE(filter_config->createFilter(), nullptr);
+#if defined(HIGRESS)
+  auto ready_wrapper =
+      std::dynamic_pointer_cast<PluginHandleSharedPtrThreadLocal>(threadlocal.data_[0]);
+  ASSERT_NE(ready_wrapper, nullptr);
+  EXPECT_TRUE(ready_wrapper->participatesInWorkerInitialization());
+  const auto recovered_handle = ready_wrapper->handle();
+  ASSERT_NE(recovered_handle, nullptr);
+#endif
 
   // If the thread local plugin handle returns nullptr, `createFilter` should return nullptr
   threadlocal.data_[0] = std::make_shared<PluginHandleSharedPtrThreadLocal>(nullptr);
   EXPECT_EQ(filter_config->createFilter(), nullptr);
+
+#if defined(HIGRESS)
+  auto worker_scope = Stats::ScopeSharedPtr(stats_store_.createScope(""));
+  auto worker_stats = std::make_shared<Envoy::Extensions::Common::Wasm::WorkerInitStatsHandler>(
+      worker_scope, proto_config.config().vm_config().runtime(), proto_config.config().name());
+  auto fail_open_plugin = std::make_shared<Envoy::Extensions::Common::Wasm::Plugin>(
+      proto_config.config(), context_.direction(), context_.localInfo(),
+      &context_.listenerMetadata());
+  const std::string stats_prefix = absl::StrCat(
+      "wasm.", proto_config.config().vm_config().runtime(), ".plugin.worker_init_test.");
+  auto& fail_open_skip =
+      worker_scope->counterFromString(stats_prefix + "worker_fail_open_skip_total");
+  auto& retry_total = worker_scope->counterFromString(stats_prefix + "worker_init_retry_total");
+  auto& recovered_total =
+      worker_scope->counterFromString(stats_prefix + "worker_init_recovered_total");
+  auto& uninitialized = worker_scope->gaugeFromString(stats_prefix + "worker_uninitialized",
+                                                      Stats::Gauge::ImportMode::NeverImport);
+
+  uint64_t factory_calls = 0;
+  auto retryable_wrapper = std::make_shared<PluginHandleSharedPtrThreadLocal>(
+      Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{nullptr,
+                                                               proxy_wasm::FailState::RuntimeError},
+      fail_open_plugin, nullptr, dispatcher_, worker_stats, false,
+      [&factory_calls, &recovered_handle]() {
+        ++factory_calls;
+        if (factory_calls == 1) {
+          return Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{
+              nullptr, proxy_wasm::FailState::RuntimeError};
+        }
+        return Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{recovered_handle,
+                                                                        proxy_wasm::FailState::Ok};
+      });
+  retryable_wrapper->setRecoveryVmKeyForTesting(
+      std::string(recovered_handle->wasmHandle()->wasm()->vm_key()));
+  threadlocal.data_[0] = retryable_wrapper;
+  EXPECT_EQ(filter_config->createFilter(), nullptr);
+  EXPECT_EQ(1, factory_calls);
+  EXPECT_EQ(1, retry_total.value());
+  EXPECT_EQ(1, fail_open_skip.value());
+  EXPECT_EQ(1, uninitialized.value());
+
+  EXPECT_EQ(filter_config->createFilter(), nullptr);
+  EXPECT_EQ(1, factory_calls);
+  EXPECT_EQ(1, retry_total.value());
+  EXPECT_EQ(2, fail_open_skip.value());
+
+  Envoy::Extensions::Common::Wasm::setTimeOffsetForCodeCacheForTesting(std::chrono::seconds(1));
+  auto recovered_filter = filter_config->createFilter();
+  EXPECT_NE(recovered_filter, nullptr);
+  EXPECT_EQ(2, factory_calls);
+  EXPECT_EQ(2, retry_total.value());
+  EXPECT_EQ(1, recovered_total.value());
+  EXPECT_EQ(0, uninitialized.value());
+  EXPECT_FALSE(retryable_wrapper->rebuild(true));
+
+  threadlocal.data_[0] = std::make_shared<PluginHandleSharedPtrThreadLocal>(
+      Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{
+          nullptr, proxy_wasm::FailState::ConfigureFailed},
+      fail_open_plugin, nullptr, dispatcher_, worker_stats);
+  EXPECT_EQ(filter_config->createFilter(), nullptr);
+  EXPECT_EQ(3, fail_open_skip.value());
+  EXPECT_EQ(1, uninitialized.value());
+
+  auto fail_closed_config = proto_config.config();
+  fail_closed_config.set_fail_open(false);
+  auto fail_closed_plugin = std::make_shared<Envoy::Extensions::Common::Wasm::Plugin>(
+      fail_closed_config, context_.direction(), context_.localInfo(), &context_.listenerMetadata());
+  uint64_t fail_closed_factory_calls = 0;
+  auto fail_closed_retryable = std::make_shared<PluginHandleSharedPtrThreadLocal>(
+      Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{nullptr,
+                                                               proxy_wasm::FailState::RuntimeError},
+      fail_closed_plugin, nullptr, dispatcher_, worker_stats, false,
+      [&fail_closed_factory_calls]() {
+        ++fail_closed_factory_calls;
+        return Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{
+            nullptr, proxy_wasm::FailState::RuntimeError};
+      });
+  fail_closed_retryable->setRecoveryVmKeyForTesting("config-fail-closed-recovery");
+  threadlocal.data_[0] = fail_closed_retryable;
+  EXPECT_NE(filter_config->createFilter(), nullptr);
+  EXPECT_EQ(1, fail_closed_factory_calls);
+  EXPECT_EQ(3, retry_total.value());
+  EXPECT_EQ(1, uninitialized.value());
+
+  threadlocal.data_[0] = std::make_shared<PluginHandleSharedPtrThreadLocal>(
+      Envoy::Extensions::Common::Wasm::ThreadLocalPluginResult{
+          nullptr, proxy_wasm::FailState::ConfigureFailed},
+      fail_closed_plugin, nullptr, dispatcher_, worker_stats);
+  auto fail_closed_filter = filter_config->createFilter();
+  ASSERT_NE(fail_closed_filter, nullptr);
+  Http::MockStreamDecoderFilterCallbacks decoder_callbacks;
+  fail_closed_filter->setDecoderFilterCallbacks(decoder_callbacks);
+  EXPECT_CALL(decoder_callbacks,
+              sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
+                             testing::Eq(Grpc::Status::WellKnownGrpcStatus::Unavailable),
+                             testing::Eq("wasm_fail_stream")))
+      .WillOnce(testing::InvokeWithoutArgs([&fail_closed_filter]() {
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "503"}};
+        EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+                  fail_closed_filter->encodeHeaders(response_headers, true));
+      }));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            fail_closed_filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ(3, fail_open_skip.value());
+  EXPECT_EQ(2, uninitialized.value());
+
+  fail_closed_retryable.reset();
+  EXPECT_EQ(1, uninitialized.value());
+
+  threadlocal.data_[0] = std::make_shared<PluginHandleSharedPtrThreadLocal>(nullptr);
+  EXPECT_EQ(0, uninitialized.value());
+#endif
 }
 
 } // namespace Wasm

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -2206,7 +2206,7 @@ TEST_P(WasmHttpFilterTest, ProactiveRebuildPrunesExpiredOldGenerations) {
   EXPECT_EQ(2U, rebuild_total.value());
 }
 
-TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenCurrentGenerationActiveWithoutOld) {
+TEST_P(WasmHttpFilterTest, ProactiveRebuildRollsActiveCurrentAndBoundsLiveOldGeneration) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {
     return;
@@ -2220,18 +2220,35 @@ TEST_P(WasmHttpFilterTest, ProactiveRebuildSkipsWhenCurrentGenerationActiveWitho
                                                   ".plugin.plugin_name.rebuild_total");
 
   PluginHandleSharedPtrThreadLocal thread_local_handle(plugin_handle_);
+  auto old_stream_context = makeStreamContext(plugin_handle_);
+  Wasm* old_wasm = old_stream_context->wasm();
+  ASSERT_NE(nullptr, old_wasm);
+  EXPECT_EQ(1U, old_wasm->activeStreamCount());
+
   advanceRebuildInterval();
   ASSERT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
   EXPECT_EQ(1U, rebuild_total.value());
+  ASSERT_NE(nullptr, thread_local_handle.handle());
+  ASSERT_NE(nullptr, thread_local_handle.handle()->wasmHandle());
+  ASSERT_NE(nullptr, thread_local_handle.handle()->wasmHandle()->wasm());
+  EXPECT_EQ(old_wasm, old_stream_context->wasm());
+  EXPECT_NE(old_wasm, thread_local_handle.handle()->wasmHandle()->wasm().get());
+  EXPECT_EQ(1U, old_wasm->activeStreamCount());
+  EXPECT_EQ(0U, thread_local_handle.handle()->wasmHandle()->wasm()->activeStreamCount());
 
-  auto current_stream_context = makeStreamContext(plugin_handle_);
-  EXPECT_EQ(1U, wasm_->wasm()->activeStreamCount());
-
+  // The active A generation is now the single live old generation, so another
+  // proactive cutover from B to C is rejected without changing success metrics.
   advanceRebuildInterval();
   EXPECT_FALSE(rebuildThroughThreadLocal(thread_local_handle));
   EXPECT_EQ(1U, rebuild_total.value());
 
-  current_stream_context->onDestroy();
+  old_stream_context->onDestroy();
+  old_stream_context.reset();
+
+  // Once the Context releases A and the cooldown has elapsed, B can roll to C.
+  advanceRebuildInterval();
+  EXPECT_TRUE(rebuildThroughThreadLocal(thread_local_handle));
+  EXPECT_EQ(2U, rebuild_total.value());
 }
 
 TEST_P(WasmHttpFilterTest, RebuildGuardRegistryRetiresStaleVmKeys) {
@@ -2324,7 +2341,7 @@ TEST_P(WasmHttpFilterTest, ActiveCounterIncludesDifferentPluginHandleOnSameGener
   EXPECT_EQ(0U, wasm_->wasm()->activeStreamCount());
 }
 
-TEST_P(WasmHttpFilterTest, FailRecoveryBypassesProactiveActiveGuard) {
+TEST_P(WasmHttpFilterTest, FailRecoveryBypassesProactiveRollingGuard) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {
     return;
@@ -2443,7 +2460,7 @@ TEST_P(WasmHttpFilterTest, ReclaimMemoryThresholdFallsBackWhenRuntimeValueIsZero
   EXPECT_EQ(800ULL * 1024 * 1024, wasm_->wasm()->reclaimMemoryThreshold());
 }
 
-TEST_P(WasmHttpFilterTest, ReclaimTimerSkipKeepsEligibleSinceUntilSuccessfulReclaim) {
+TEST_P(WasmHttpFilterTest, ReclaimTimerLiveOldSkipKeepsEligibleSinceUntilSuccessfulReclaim) {
   auto runtime = std::get<0>(GetParam());
   if (runtime == "null") {
     return;
@@ -2457,23 +2474,35 @@ TEST_P(WasmHttpFilterTest, ReclaimTimerSkipKeepsEligibleSinceUntilSuccessfulRecl
                                                   ".plugin.plugin_name.rebuild_total");
 
   auto thread_local_handle = makeThreadLocalHandle(true);
-  auto stream_context = makeStreamContext(plugin_handle_);
-  auto wasm = thread_local_handle->handle()->wasmHandle()->wasm();
-  wasm->setShouldRebuild(true);
+  auto old_stream_context = makeStreamContext(plugin_handle_);
+  auto old_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  old_wasm->setShouldRebuild(true);
+  old_wasm->markReclaimEligible();
 
-  advanceRebuildInterval();
-  thread_local_handle->runReclaimTimerForTesting();
-
-  EXPECT_EQ(0U, rebuild_total.value());
-  EXPECT_TRUE(wasm->reclaimEligibleSinceForTesting().has_value());
-
-  stream_context->onDestroy();
   advanceRebuildInterval();
   thread_local_handle->runReclaimTimerForTesting();
   adoptThreadLocalHandle(*thread_local_handle);
 
   EXPECT_EQ(1U, rebuild_total.value());
-  EXPECT_FALSE(wasm->reclaimEligibleSinceForTesting().has_value());
+  EXPECT_FALSE(old_wasm->reclaimEligibleSinceForTesting().has_value());
+
+  auto current_wasm = thread_local_handle->handle()->wasmHandle()->wasm();
+  current_wasm->setShouldRebuild(true);
+  current_wasm->markReclaimEligible();
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+
+  EXPECT_EQ(1U, rebuild_total.value());
+  EXPECT_TRUE(current_wasm->reclaimEligibleSinceForTesting().has_value());
+
+  old_stream_context->onDestroy();
+  old_stream_context.reset();
+  advanceRebuildInterval();
+  thread_local_handle->runReclaimTimerForTesting();
+  adoptThreadLocalHandle(*thread_local_handle);
+
+  EXPECT_EQ(2U, rebuild_total.value());
+  EXPECT_FALSE(current_wasm->reclaimEligibleSinceForTesting().has_value());
 }
 
 TEST_P(WasmHttpFilterTest, ReclaimTimerStillHonorsRecoverInterval) {

--- a/verification/examples/wasm-vm-reclaim/README.md
+++ b/verification/examples/wasm-vm-reclaim/README.md
@@ -1,0 +1,95 @@
+# Proactive Wasm VM Reclaim — Runtime Artifacts
+
+Reproducible local runtime assets for timer/memory reclaim, generation
+replacement and ECDS churn. The original execution record is in
+[`../../reports/proactive-wasm-vm-reclaim.md`](../../reports/proactive-wasm-vm-reclaim.md).
+
+## Shared Upstream
+
+```bash
+python3 verification/examples/wasm-vm-reclaim/upstream_server.py
+```
+
+Listens on `127.0.0.1:3080`; supports `/slow?delay=N` to hold a downstream
+request active (used by the active-stream / cap experiments).
+
+## Timer-Reclaim Scenario (bounded rolling reclaim + memory threshold + observability)
+
+The plugin (`timer-reclaim/wasm/main.go`) is a single flexible module driven by
+request headers:
+
+- `x-set-rebuild: true` → sets the `wasm_need_rebuild` property (host
+  `shouldRebuild(true)`); explicit-flag trigger source.
+- `x-alloc-mb: N` → idempotently grows a VM-retained buffer to at least `N` MiB
+  and touches every new page so WASM linear memory grows past the reclaim threshold;
+  memory-threshold trigger source (independent of the plugin flag).
+- `x-hold-active: true` → holds a Context without implicitly selecting a rebuild
+  source. It can be combined with either trigger.
+
+The self-verdict runner lowers the reclaim memory threshold to **32 MiB** via a `layered_runtime`
+override (`envoy.wasm.reclaim.memory_threshold_bytes`) so a modest allocation can
+cross it without making the 4 MiB explicit-source marker eligible; the default is
+800 MiB. The checked-in manual config retains its original 16 MiB threshold.
+
+Build:
+
+```bash
+cd verification/examples/wasm-vm-reclaim/timer-reclaim/wasm
+GOWORK=off GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o ../reclaim-verify.wasm .
+```
+
+Run the self-verdict harness against an explicitly selected Envoy binary:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static \
+  verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh all
+```
+
+See `timer-reclaim/README.md` for the four-worker formal profile, declared
+near-OOM safety envelope, evidence files and exact TASK/SPEC traceability.
+Listener `10002`, admin `9905`. Stats scope:
+`wasm.envoy.wasm.runtime.v8.plugin.reclaim_verify_plugin.<stat>`.
+
+## Fail Recovery Crash Scenario (unchanged fail recovery — regression guard)
+
+Copied verbatim from `optimize-wasm-rebuild-guard` (behavior is unchanged by this
+change). Build:
+
+```bash
+cd verification/examples/wasm-vm-reclaim/fail-recovery-crash/wasm
+GOWORK=off GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o ../crash-recovery.wasm .
+```
+
+Run from `fail-recovery-crash` (listener `10001`, admin `9904`).
+
+## ECDS File Update Scenario (file xDS + cp/mv ECDS update)
+
+`ecds-file-update/` loads LDS from a file, uses `config_discovery.path` for the
+HTTP Wasm filter, and updates ECDS by copying a candidate to a temporary path
+and atomically moving it into place.
+
+Run from the repository root:
+
+```bash
+verification/examples/wasm-vm-reclaim/ecds-file-update/run.sh
+```
+
+The script verifies ECDS plugin configuration updates (`v1` -> `v2`), same-VM-key
+wrapper replacement preserving reclaim state, Wasm binary A/B updates that change
+`vm_key` through code bytes (`v4` / `v5`), pending rebuild plus binary-update
+collision behavior, post-binary explicit-flag reclaim, no-residue active VM lifecycle
+sanity, legal `vm_id` / `vm_key` change (`v3`), and memory-threshold reclaim
+after the ECDS update.
+
+## Ablation
+
+The same `timer-reclaim` inputs (plugin + config) are run against two binaries:
+
+- **baseline**: develop build (has `optimize-wasm-rebuild-guard` request-path
+  rebuild + idle-allow; no timer, no memory trigger, no two-gen cap).
+- **current**: post-implementation build of this change (timer-only non-fail
+  reclaim + memory threshold + bounded rolling cutover + source counters + latency).
+
+Generated Wasm binaries and runtime logs are intentionally not retained. Build
+them from the checked-in Go sources and record the current checksums and
+observations in the active VERIFY.

--- a/verification/examples/wasm-vm-reclaim/timer-reclaim/README.md
+++ b/verification/examples/wasm-vm-reclaim/timer-reclaim/README.md
@@ -1,0 +1,105 @@
+# Bounded rolling Wasm reclaim verification
+
+`run.sh` is a self-verdict runtime harness for the HIGRESS worker-local reclaim timer. It uses a
+real Envoy binary, a real Go Proxy-Wasm module and held upstream calls. It never treats an RSS
+sample as proof that an old generation retired: the verdict is based on response generation
+markers, per-source success counters, the reclaim-latency sample count and the live-old guard.
+
+The module exposes the retained bytes captured by each stream in
+`x-reclaim-retained-bytes`. A is deliberately marked with retained memory before it is held; a
+successful A -> B cutover therefore produces new responses with `0` while the eventual held A
+response still reports A's non-zero marker. Every worker Plugin Context generates a per-start
+token; those response tokens are collected for every phase, so `CONCURRENCY=4` fails unless
+baseline, B and C probes, both eligibility triggers and the held A/B sets visit all four workers.
+
+## Smoke run
+
+Build the changed Envoy first, then run:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static \
+  verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh all
+```
+
+The default single-worker campaign runs:
+
+- explicit eligibility with active A and idle B;
+- memory-threshold eligibility with active A and active B;
+- a sustained healthy control with no eligibility signal;
+- repeated cutovers under continuous request traffic.
+
+The soak traffic loop is part of the verdict, not background noise: it publishes a successful
+request count, must make progress in every cycle, and must exit cleanly after the runner writes
+its stop marker. Any early curl exit fails the campaign and is retained in `traffic.error`.
+
+Each rolling case proves that active A can cut over to B, A continues with its original marker,
+new requests use B, live A rejects B -> C without changing counters or latency samples, and B can
+cut over exactly once after A retires. The memory case also proves that B activity is not a
+quiescence gate. Explicit and memory counters must remain source-exclusive; `recover_total` must
+stay zero. `guard-window.txt` records wall-clock start/end timestamps and elapsed milliseconds;
+the runner requires held A requests to remain live across at least two complete one-second timer
+intervals.
+
+## Formal and near-OOM profiles
+
+The formal profile declares its duration and worker count before Envoy starts and refuses a
+shortened campaign:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static PROFILE=formal CONCURRENCY=4 \
+  SOAK_CYCLES=600 CONTROL_SECONDS=300 \
+  WORKDIR=/tmp/wasm-timer-reclaim-formal \
+  verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh all
+```
+
+Both evidence profiles bind the executable to its sources. The runner parses the exact
+40-character commit and `Clean` state from `ENVOY_BIN --version`, verifies that commit in
+`ENVOY_SOURCE_REPO` (the current Envoy checkout by default), reads the Host dependency pin from
+that exact commit, and resolves its tree from `HOST_SOURCE_REPO` (the sibling Host checkout by
+default). Formal and near-OOM runs fail closed if any part cannot be verified. Smoke runs record
+`unknown` instead of associating an unverified binary with the current checkout. Set
+`EXPECTED_ENVOY_HEAD` to add an exact binary-head assertion.
+
+Near-OOM testing must additionally declare the VM limit, estimated runtime overhead, retained
+target and minimum remaining headroom. The runner rejects a target outside the declared safety
+envelope and records every resolved value before allocation:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static PROFILE=near-oom \
+  MEMORY_THRESHOLD_BYTES=805306368 MEMORY_TARGET_MB=800 \
+  DECLARED_VM_LIMIT_BYTES=1073741824 DECLARED_VM_OVERHEAD_BYTES=67108864 \
+  MIN_HEADROOM_BYTES=134217728 \
+  VM_LIMIT_PROVENANCE='proxy-wasm-cpp-host d9c5587 include/proxy-wasm/limits.h PROXY_WASM_HOST_MAX_WASM_MEMORY_SIZE_BYTES=1GiB' \
+  verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh memory-active
+```
+
+`PROFILE=near-oom` fails closed unless the threshold, all four sizing inputs and
+`VM_LIMIT_PROVENANCE` are explicitly supplied; smoke defaults are never promoted into near-OOM
+evidence. The declared peak includes the target allocation, the pre-existing A marker and the
+runtime overhead. For every covered worker in both A-eligible and B-eligible phases, the runner
+then validates the response's actual `x-reclaim-vm-memory-bytes`: it must cross the configured
+threshold, not exceed the declared peak, and leave between one and two times the declared minimum
+headroom. The per-worker observations are written to `near-oom-vm-memory.csv`; maxima and minimum
+observed headroom are also appended to the manifest. Choose values for the compiled runtime's
+actual linear-memory limit; the example leaves 156 MiB after including the 4 MiB marker and 64 MiB
+runtime estimate. An operator should lower the target when host memory pressure or other
+concurrent builds make that envelope unsafe.
+
+The module grows one target-sized retained backing slice and touches its new pages directly. It
+does not create a second target-sized temporary allocation before copying, which would invalidate
+the declared headroom near the Host hard limit.
+
+The harness writes config, binary hashes, binary/source/Host provenance, resolved safety inputs,
+response headers/bodies, per-phase worker IDs, stats/resource samples and Envoy logs under
+`WORKDIR`. `resources.csv` is
+useful for the long-run memory assessment, but the expected product behavior is bounded rolling
+generation ownership and quick creation of the latest VM, not immediate RSS decrease while a
+long-lived old Context exists.
+
+Before normal shutdown, each case requires the active VM gauge to return to its startup baseline.
+After SIGTERM it also requires the debug lifecycle log to drain to at most the process-global
+cached base; depending on shutdown/log ordering Envoy may log either one remaining base or the
+subsequent zero.
+
+See [TRACEABILITY.md](TRACEABILITY.md) for the complete TASK/SPEC evidence map, including the
+separate old/new Host pin NACK and fail-recovery guard campaigns.

--- a/verification/examples/wasm-vm-reclaim/timer-reclaim/TRACEABILITY.md
+++ b/verification/examples/wasm-vm-reclaim/timer-reclaim/TRACEABILITY.md
@@ -1,0 +1,27 @@
+# TASK-11001 verification traceability
+
+| Contract | Focused evidence | Runtime evidence |
+| --- | --- | --- |
+| Active current with no old generation may cut over | `WasmHttpFilterTest.ProactiveRebuildRollsActiveCurrentAndBoundsLiveOldGeneration` | `run.sh explicit-idle` and `run.sh memory-active`: non-zero held A marker, zero B marker, first counter/latency delta before A response |
+| At most one live old generation | active/idle live-old unit tests plus the rolling test's rejected second cutover | both rolling cases require no B -> C counter or latency change while A is held across at least two complete timer intervals, record the actual guard start/end/elapsed, then allow exactly one cutover after A retires |
+| Old Context remains on A; new requests use B | rolling unit test compares the Context's `wasm()` with A while the wrapper points at B | held A response retains A bytes; per-worker B/C probes report zero |
+| Weak old tracking does not retain A | `ProactiveRebuildPrunesExpiredOldGenerations` | B -> C becomes possible without an explicit old-generation cleanup API after held A responses complete |
+| Timer explicit and memory sources; current activity is not a gate | reclaim timer source tests and active rolling test | explicit-idle and memory-active cases; the latter holds B during B -> C |
+| Success-only source counters and reclaim latency | timer skip/success tests and counter assertions | every successful cutover increments exactly one source counter and latency count; live-old skips change neither |
+| Fail recovery remains under the existing one-second guard | `FailRecoveryBypassesProactiveRollingGuard` and worker initialization/recovery unit tests | `verification/examples/wasm-worker-init-failure/request-recovery/run.sh` (first ready recovery and later >1 s attempts) |
+| Same-key worker clone failure does not poison the healthy base or cause later config NACK | `//test/extensions/common/wasm:wasm_test`, `WorkerCloneFailureDoesNotPoisonBaseOrNackNextSameVmKeyConfig` | compile Envoy once with the branch's previous Host pin for the red baseline and once with Higress Host revision `d9c558753df6781388e36e0d51adc98c0b6835a0` for green; run the common test and the `wasm-worker-init-failure` static/ECDS matrix against each binary, retaining LDS/config logs |
+| Continuous trap/recover and healthy-control memory stability | worker-init recovery unit tests | `verification/examples/wasm-worker-init-failure/soak/run.sh` formal `SCENARIO=all`; pair with `run.sh soak` here, whose continuous-traffic heartbeat must advance in every cycle and exit cleanly |
+| Near-OOM envelope applies to actual VM memory | response header reports the Host `plugin_vm_memory` property | `PROFILE=near-oom` checks every A/B eligibility worker observation against threshold, declared peak and 1x-2x minimum remaining headroom; CSV plus manifest retain the actual values |
+| Non-HIGRESS behavior unchanged | production diff is inside the existing HIGRESS implementation | build/test a non-HIGRESS configuration; this harness requires the HIGRESS counters/timer and therefore fails closed when they are absent |
+
+The old/new Host pin comparison is intentionally a two-binary campaign. Higress loads this
+dependency from the GitHub archive selected by `version`; `sha256` validates that archive.
+Evidence records the resolved 40-character `version` from the exact Envoy source commit and
+verifies the corresponding Host commit tree.
+
+For Higress Host revision `d9c558753df6781388e36e0d51adc98c0b6835a0`, the expected commit
+tree is `9cdf1a9ed40d945f94af5c8ea458892c383b818e`. The runner first extracts the exact
+Envoy source commit from the selected binary, reads `proxy_wasm_cpp_host.version` from that
+commit's `bazel/repository_locations.bzl`, and resolves the Host tree from the configured checkout.
+Formal and near-OOM evidence fails if this chain is incomplete; smoke evidence records `unknown`
+rather than borrowing the current checkout's dependency pin.

--- a/verification/examples/wasm-vm-reclaim/timer-reclaim/config.yaml.template
+++ b/verification/examples/wasm-vm-reclaim/timer-reclaim/config.yaml.template
@@ -1,0 +1,75 @@
+node:
+  cluster: timer-reclaim-verification
+  id: timer-reclaim-verification
+
+stats_flush_interval: 1s
+
+admin:
+  address:
+    socket_address:
+      protocol: TCP
+      address: 127.0.0.1
+      port_value: __ADMIN_PORT__
+
+layered_runtime:
+  layers:
+    - name: reclaim_threshold_override
+      static_layer:
+        envoy:
+          wasm:
+            reclaim:
+              memory_threshold_bytes: __MEMORY_THRESHOLD_BYTES__
+
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: __LISTENER_PORT__
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: outbound|80||httpbin.dns
+                http_filters:
+                  - name: envoy.filters.http.wasm
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                      config:
+                        name: reclaim_verify_plugin
+                        fail_open: false
+                        vm_config:
+                          vm_id: reclaim_vm
+                          runtime: envoy.wasm.runtime.v8
+                          code:
+                            local:
+                              filename: __WASM_BINARY__
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: outbound|80||httpbin.dns
+      connect_timeout: 5s
+      type: STATIC
+      load_assignment:
+        cluster_name: outbound|80||httpbin.dns
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: __UPSTREAM_PORT__

--- a/verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh
+++ b/verification/examples/wasm-vm-reclaim/timer-reclaim/run.sh
@@ -1,0 +1,910 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+MEMORY_TARGET_EXPLICIT="${MEMORY_TARGET_MB+x}"
+MEMORY_THRESHOLD_EXPLICIT="${MEMORY_THRESHOLD_BYTES+x}"
+VM_LIMIT_EXPLICIT="${DECLARED_VM_LIMIT_BYTES+x}"
+VM_OVERHEAD_EXPLICIT="${DECLARED_VM_OVERHEAD_BYTES+x}"
+HEADROOM_EXPLICIT="${MIN_HEADROOM_BYTES+x}"
+ENVOY_BIN="${ENVOY_BIN:-}"
+ENVOY_SOURCE_REPO="${ENVOY_SOURCE_REPO:-${REPO_ROOT}}"
+HOST_SOURCE_REPO="${HOST_SOURCE_REPO:-${REPO_ROOT}/../proxy-wasm-cpp-host}"
+EXPECTED_ENVOY_HEAD="${EXPECTED_ENVOY_HEAD:-}"
+WASM_BINARY="${WASM_BINARY:-}"
+WORKDIR="${WORKDIR:-/tmp/wasm-timer-reclaim}"
+PROFILE="${PROFILE:-smoke}"
+CASE="${1:-all}"
+LISTENER_PORT="${LISTENER_PORT:-10002}"
+ADMIN_PORT="${ADMIN_PORT:-9905}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3082}"
+BASE_ID="${BASE_ID:-192}"
+CONCURRENCY="${CONCURRENCY:-1}"
+MEMORY_THRESHOLD_BYTES="${MEMORY_THRESHOLD_BYTES:-33554432}"
+MEMORY_TARGET_MB="${MEMORY_TARGET_MB:-40}"
+EXPLICIT_MARKER_MB="${EXPLICIT_MARKER_MB:-4}"
+DECLARED_VM_LIMIT_BYTES="${DECLARED_VM_LIMIT_BYTES:-134217728}"
+DECLARED_VM_OVERHEAD_BYTES="${DECLARED_VM_OVERHEAD_BYTES:-33554432}"
+MIN_HEADROOM_BYTES="${MIN_HEADROOM_BYTES:-33554432}"
+VM_LIMIT_PROVENANCE="${VM_LIMIT_PROVENANCE:-}"
+HOLD_SECONDS="${HOLD_SECONDS:-20}"
+GUARD_OBSERVE_SECONDS="${GUARD_OBSERVE_SECONDS:-2.25}"
+RECLAIM_TIMER_INTERVAL_MS=1000
+MIN_GUARD_OBSERVE_MS=$((2 * RECLAIM_TIMER_INTERVAL_MS))
+CUTOVER_DEADLINE_SECONDS="${CUTOVER_DEADLINE_SECONDS:-8}"
+STEERING_REQUEST_LIMIT="${STEERING_REQUEST_LIMIT:-80}"
+HOLD_REQUEST_MULTIPLIER="${HOLD_REQUEST_MULTIPLIER:-2}"
+CONTROL_SECONDS="${CONTROL_SECONDS:-5}"
+SOAK_CYCLES="${SOAK_CYCLES:-4}"
+MAX_RSS_GROWTH_KB="${MAX_RSS_GROWTH_KB:-262144}"
+MAX_FD_GROWTH="${MAX_FD_GROWTH:-12}"
+TRAFFIC_FAIL_AFTER="${TRAFFIC_FAIL_AFTER:-0}"
+WORKDIR_MARKER=.envoy-verification-workdir
+ENVOY_PID=""
+UPSTREAM_PID=""
+TRAFFIC_PID=""
+TRAFFIC_STOP_FILE=""
+TRAFFIC_COUNT_FILE=""
+TRAFFIC_ERROR_FILE=""
+ENVOY_VERSION_OUTPUT=""
+BINARY_ENVOY_HEAD="unknown"
+BINARY_BUILD_STATE="unknown"
+ENVOY_SOURCE_VERIFIED="false"
+RESOLVED_HOST_PIN="unknown"
+RESOLVED_HOST_PIN_SOURCE="unavailable"
+RESOLVED_HOST_TREE="unknown"
+RESOLVED_HOST_TREE_SOURCE="unavailable"
+declare -a A_HOLD_PIDS=()
+declare -a B_HOLD_PIDS=()
+
+case "${CASE}" in
+  all|explicit-idle|memory-active|control|soak) ;;
+  *) echo "usage: $0 [all|explicit-idle|memory-active|control|soak]" >&2; exit 2 ;;
+esac
+case "${PROFILE}" in
+  smoke|formal|near-oom) ;;
+  *) echo "PROFILE must be smoke, formal, or near-oom" >&2; exit 2 ;;
+esac
+if [[ -z "${ENVOY_BIN}" || "${ENVOY_BIN}" != /* || ! -x "${ENVOY_BIN}" ]]; then
+  echo "ENVOY_BIN must explicitly name an absolute executable Envoy binary" >&2
+  exit 1
+fi
+for pair in "CONCURRENCY:${CONCURRENCY}" "MEMORY_THRESHOLD_BYTES:${MEMORY_THRESHOLD_BYTES}" \
+  "MEMORY_TARGET_MB:${MEMORY_TARGET_MB}" "EXPLICIT_MARKER_MB:${EXPLICIT_MARKER_MB}" \
+  "DECLARED_VM_LIMIT_BYTES:${DECLARED_VM_LIMIT_BYTES}" \
+  "DECLARED_VM_OVERHEAD_BYTES:${DECLARED_VM_OVERHEAD_BYTES}" \
+  "MIN_HEADROOM_BYTES:${MIN_HEADROOM_BYTES}" \
+  "HOLD_SECONDS:${HOLD_SECONDS}" "CUTOVER_DEADLINE_SECONDS:${CUTOVER_DEADLINE_SECONDS}" \
+  "STEERING_REQUEST_LIMIT:${STEERING_REQUEST_LIMIT}" \
+  "HOLD_REQUEST_MULTIPLIER:${HOLD_REQUEST_MULTIPLIER}" \
+  "CONTROL_SECONDS:${CONTROL_SECONDS}" \
+  "SOAK_CYCLES:${SOAK_CYCLES}"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 2
+  fi
+done
+if [[ ! "${TRAFFIC_FAIL_AFTER}" =~ ^[0-9]+$ ]]; then
+  echo "TRAFFIC_FAIL_AFTER must be a non-negative integer" >&2
+  exit 2
+fi
+if [[ "${PROFILE}" == formal && "${CONCURRENCY}" != 4 ]]; then
+  echo "PROFILE=formal requires CONCURRENCY=4" >&2
+  exit 2
+fi
+if [[ "${PROFILE}" == formal ]] && (( SOAK_CYCLES < 600 || CONTROL_SECONDS < 300 )); then
+  echo "PROFILE=formal requires SOAK_CYCLES>=600 and CONTROL_SECONDS>=300" >&2
+  exit 2
+fi
+if [[ "${PROFILE}" == near-oom ]]; then
+  if [[ "${CASE}" != memory-active && "${CASE}" != all ]]; then
+    echo "PROFILE=near-oom requires CASE=memory-active or CASE=all" >&2
+    exit 2
+  fi
+  if [[ -z "${MEMORY_TARGET_EXPLICIT}" || -z "${MEMORY_THRESHOLD_EXPLICIT}" ||
+        -z "${VM_LIMIT_EXPLICIT}" ||
+        -z "${VM_OVERHEAD_EXPLICIT}" || -z "${HEADROOM_EXPLICIT}" ||
+        -z "${VM_LIMIT_PROVENANCE}" ]]; then
+    echo "PROFILE=near-oom requires explicit MEMORY_THRESHOLD_BYTES, MEMORY_TARGET_MB, DECLARED_VM_LIMIT_BYTES, DECLARED_VM_OVERHEAD_BYTES, MIN_HEADROOM_BYTES, and VM_LIMIT_PROVENANCE" >&2
+    exit 2
+  fi
+fi
+if [[ ! "${GUARD_OBSERVE_SECONDS}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "GUARD_OBSERVE_SECONDS must be a non-negative number" >&2
+  exit 2
+fi
+guard_observe_ms="$(awk -v seconds="${GUARD_OBSERVE_SECONDS}" \
+  'BEGIN { printf "%.0f", seconds * 1000 }')"
+case "${CASE}" in
+  all|explicit-idle|memory-active)
+    if (( guard_observe_ms < MIN_GUARD_OBSERVE_MS )); then
+      echo "rolling evidence requires GUARD_OBSERVE_SECONDS to cover at least two full 1-second timer intervals (${MIN_GUARD_OBSERVE_MS}ms)" >&2
+      exit 2
+    fi
+    ;;
+esac
+
+memory_target_bytes=$((MEMORY_TARGET_MB * 1024 * 1024))
+marker_bytes=$((EXPLICIT_MARKER_MB * 1024 * 1024))
+declared_peak_bytes=$((memory_target_bytes + marker_bytes + DECLARED_VM_OVERHEAD_BYTES))
+if (( memory_target_bytes < MEMORY_THRESHOLD_BYTES )); then
+  echo "MEMORY_TARGET_MB must cross MEMORY_THRESHOLD_BYTES" >&2
+  exit 2
+fi
+if (( declared_peak_bytes + MIN_HEADROOM_BYTES > DECLARED_VM_LIMIT_BYTES )); then
+  echo "memory target violates declared VM headroom: target=${memory_target_bytes}, overhead=${DECLARED_VM_OVERHEAD_BYTES}, headroom=${MIN_HEADROOM_BYTES}, limit=${DECLARED_VM_LIMIT_BYTES}" >&2
+  exit 2
+fi
+if [[ "${PROFILE}" == near-oom ]] && (( DECLARED_VM_LIMIT_BYTES - declared_peak_bytes > MIN_HEADROOM_BYTES * 2 )); then
+  echo "PROFILE=near-oom requires the target to finish within 2x MIN_HEADROOM_BYTES of DECLARED_VM_LIMIT_BYTES" >&2
+  exit 2
+fi
+
+resolve_binary_provenance() {
+  local version_payload locations
+  if ! ENVOY_VERSION_OUTPUT="$("${ENVOY_BIN}" --version 2>&1)"; then
+    echo "failed to read Envoy binary version from ${ENVOY_BIN}" >&2
+    return 1
+  fi
+  version_payload="$(printf '%s\n' "${ENVOY_VERSION_OUTPUT}" |
+    sed -n 's#^.* version: ##p' | head -1)"
+  BINARY_ENVOY_HEAD="${version_payload%%/*}"
+  BINARY_BUILD_STATE="$(printf '%s\n' "${version_payload}" | awk -F/ '{print $3}')"
+  if [[ ! "${BINARY_ENVOY_HEAD}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Envoy --version did not expose an exact 40-character source commit" >&2
+    return 1
+  fi
+  if [[ -n "${EXPECTED_ENVOY_HEAD}" && "${BINARY_ENVOY_HEAD}" != "${EXPECTED_ENVOY_HEAD}" ]]; then
+    echo "Envoy binary commit ${BINARY_ENVOY_HEAD} does not match EXPECTED_ENVOY_HEAD=${EXPECTED_ENVOY_HEAD}" >&2
+    return 1
+  fi
+  if git -C "${ENVOY_SOURCE_REPO}" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git -C "${ENVOY_SOURCE_REPO}" cat-file -e "${BINARY_ENVOY_HEAD}^{commit}" 2>/dev/null; then
+    ENVOY_SOURCE_VERIFIED=true
+  fi
+  if [[ "${ENVOY_SOURCE_VERIFIED}" == true && "${BINARY_BUILD_STATE}" == Clean ]]; then
+    locations="$(git -C "${ENVOY_SOURCE_REPO}" \
+      show "${BINARY_ENVOY_HEAD}:bazel/repository_locations.bzl" 2>/dev/null || true)"
+    RESOLVED_HOST_PIN="$(printf '%s\n' "${locations}" |
+      awk '/proxy_wasm_cpp_host = dict\(/ {in_host=1} in_host && /version =/ {gsub(/[",]/, "", $3); print $3; exit}')"
+    if [[ "${RESOLVED_HOST_PIN}" =~ ^[0-9a-f]{40}$ ]]; then
+      RESOLVED_HOST_PIN_SOURCE=envoy-binary-source-commit
+    else
+      RESOLVED_HOST_PIN=unknown
+    fi
+  fi
+  if [[ "${RESOLVED_HOST_PIN}" != unknown ]] &&
+    git -C "${HOST_SOURCE_REPO}" rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git -C "${HOST_SOURCE_REPO}" cat-file -e "${RESOLVED_HOST_PIN}^{commit}" 2>/dev/null; then
+    RESOLVED_HOST_TREE="$(git -C "${HOST_SOURCE_REPO}" show -s --format=%T \
+      "${RESOLVED_HOST_PIN}")"
+    RESOLVED_HOST_TREE_SOURCE=host-source-repo
+  fi
+  if [[ -n "${HOST_COMMIT_TREE:-}" && "${RESOLVED_HOST_TREE}" != unknown &&
+        "${HOST_COMMIT_TREE}" != "${RESOLVED_HOST_TREE}" ]]; then
+    echo "resolved Host tree ${RESOLVED_HOST_TREE} does not match HOST_COMMIT_TREE=${HOST_COMMIT_TREE}" >&2
+    return 1
+  fi
+  if [[ "${PROFILE}" == formal || "${PROFILE}" == near-oom ]]; then
+    if [[ "${BINARY_BUILD_STATE}" != Clean || "${ENVOY_SOURCE_VERIFIED}" != true ||
+          "${RESOLVED_HOST_PIN}" == unknown || "${RESOLVED_HOST_TREE}" == unknown ]]; then
+      echo "${PROFILE} evidence requires a clean exact Envoy binary commit plus verifiable Envoy-source Host pin and Host commit tree" >&2
+      return 1
+    fi
+  fi
+}
+
+resolve_binary_provenance
+
+tmp_root="$(realpath -m /tmp)"
+WORKDIR="$(realpath -m "${WORKDIR}")"
+case "${WORKDIR}" in
+  "${tmp_root}"/?*) ;;
+  *) echo "WORKDIR must be a dedicated directory below ${tmp_root}" >&2; exit 1 ;;
+esac
+if [[ -d "${WORKDIR}" && ! -f "${WORKDIR}/${WORKDIR_MARKER}" ]] &&
+  find "${WORKDIR}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "refusing to clean unmarked non-empty WORKDIR: ${WORKDIR}" >&2
+  exit 1
+fi
+mkdir -p "${WORKDIR}"
+touch "${WORKDIR}/${WORKDIR_MARKER}"
+find "${WORKDIR}" -mindepth 1 -depth ! -path "${WORKDIR}/${WORKDIR_MARKER}" -delete
+
+cleanup_envoy() {
+  if [[ -n "${TRAFFIC_PID}" ]]; then
+    [[ -n "${TRAFFIC_STOP_FILE}" ]] && touch "${TRAFFIC_STOP_FILE}"
+    kill "${TRAFFIC_PID}" >/dev/null 2>&1 || true
+    wait "${TRAFFIC_PID}" >/dev/null 2>&1 || true
+    TRAFFIC_PID=""
+    TRAFFIC_STOP_FILE=""
+    TRAFFIC_COUNT_FILE=""
+    TRAFFIC_ERROR_FILE=""
+  fi
+  if [[ -n "${ENVOY_PID}" ]]; then
+    kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+    wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+    ENVOY_PID=""
+  fi
+}
+stop_envoy_and_assert_lifecycle() {
+  local case_dir="$1"
+  if [[ -n "${ENVOY_PID}" ]]; then
+    kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+    wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+    ENVOY_PID=""
+  fi
+  local remaining
+  remaining="$({ grep '~Wasm [0-9][0-9]* remaining active' "${case_dir}/envoy.log" || true; } |
+    tail -1 | sed -n 's/.*~Wasm \([0-9][0-9]*\) remaining active.*/\1/p')"
+  if [[ -z "${remaining}" ]] || (( remaining > 1 )); then
+    echo "normal shutdown left more than the process-global cached base: remaining=${remaining:-unknown}" >&2
+    return 1
+  fi
+}
+cleanup_all() {
+  cleanup_envoy
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    UPSTREAM_PID=""
+  fi
+}
+trap cleanup_all EXIT
+
+if [[ -n "${WASM_BINARY}" ]]; then
+  if [[ "${WASM_BINARY}" != /* || ! -f "${WASM_BINARY}" ]]; then
+    echo "WASM_BINARY must name an absolute existing file" >&2
+    exit 1
+  fi
+else
+  WASM_BINARY="${WORKDIR}/reclaim-verify.wasm"
+  (cd "${SCRIPT_DIR}/wasm" && GOWORK=off GOOS=wasip1 GOARCH=wasm \
+    go build -buildmode=c-shared -o "${WASM_BINARY}" .)
+fi
+WASM_BINARY="$(realpath "${WASM_BINARY}")"
+
+UPSTREAM_PORT="${UPSTREAM_PORT}" python3 "${SCRIPT_DIR}/../upstream_server.py" \
+  >"${WORKDIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+for _ in $(seq 1 80); do
+  if curl --fail --silent --max-time 1 "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+curl --fail --silent --show-error --max-time 2 \
+  "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null
+
+prefix=wasm.envoy.wasm.runtime.v8.plugin.reclaim_verify_plugin
+rebuild_stat="${prefix}.rebuild_total"
+explicit_stat="${prefix}.rebuild_explicit_total"
+memory_stat="${prefix}.rebuild_memory_total"
+recover_stat="${prefix}.recover_total"
+active_stat=wasm.envoy.wasm.runtime.v8.active
+
+render_config() {
+  local output="$1"
+  sed -e "s#__ADMIN_PORT__#${ADMIN_PORT}#g" \
+    -e "s#__LISTENER_PORT__#${LISTENER_PORT}#g" \
+    -e "s#__UPSTREAM_PORT__#${UPSTREAM_PORT}#g" \
+    -e "s#__MEMORY_THRESHOLD_BYTES__#${MEMORY_THRESHOLD_BYTES}#g" \
+    -e "s#__WASM_BINARY__#${WASM_BINARY}#g" \
+    "${SCRIPT_DIR}/config.yaml.template" >"${output}"
+}
+stat_value() {
+  local stat="$1"
+  curl --fail --silent --show-error --max-time 2 \
+    "http://127.0.0.1:${ADMIN_PORT}/stats?filter=^${stat}$" |
+    awk -F': ' -v stat="${stat}" '$1 == stat {print $2; found=1} END {if (!found) print 0}'
+}
+latency_count() {
+  curl --fail --silent --show-error --max-time 2 \
+    "http://127.0.0.1:${ADMIN_PORT}/stats/prometheus?filter=reclaim_latency" |
+    awk '$1 ~ /reclaim_latency_count/ {sum += $2} END {print sum + 0}'
+}
+wait_stat_at_least() {
+  local stat="$1" expected="$2" deadline=$((SECONDS + CUTOVER_DEADLINE_SECONDS)) value=0
+  while (( SECONDS <= deadline )); do
+    value="$(stat_value "${stat}")"
+    if (( value >= expected )); then
+      echo "${stat}=${value} reached expected minimum ${expected}"
+      return 0
+    fi
+    sleep 0.20
+  done
+  echo "timed out waiting for ${stat}>=${expected}; last=${value}" >&2
+  return 1
+}
+wait_latency_at_least() {
+  local expected="$1" deadline=$((SECONDS + CUTOVER_DEADLINE_SECONDS)) value=0
+  while (( SECONDS <= deadline )); do
+    value="$(latency_count)"
+    if (( value >= expected )); then
+      echo "reclaim_latency_count=${value} reached expected minimum ${expected}"
+      return 0
+    fi
+    sleep 0.20
+  done
+  echo "timed out waiting for reclaim_latency_count>=${expected}; last=${value}" >&2
+  return 1
+}
+proc_rss_kb() {
+  awk '/VmRSS:/ {print $2; found=1} END {if (!found) print 0}' \
+    "/proc/${ENVOY_PID}/status" 2>/dev/null || echo 0
+}
+proc_fd_count() {
+  find "/proc/${ENVOY_PID}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l
+}
+record_resources() {
+  local case_dir="$1" phase="$2"
+  printf '%s,%s,%s,%s,%s,%s,%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${phase}" \
+    "$(proc_rss_kb)" "$(proc_fd_count)" "$(stat_value "${active_stat}")" \
+    "$(stat_value "${rebuild_stat}")" "$(latency_count)" >>"${case_dir}/resources.csv"
+}
+traffic_success_count() {
+  local count=0
+  if [[ -f "${TRAFFIC_COUNT_FILE}" ]]; then
+    count="$(<"${TRAFFIC_COUNT_FILE}")"
+  fi
+  [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+  printf '%s\n' "${count}"
+}
+start_continuous_traffic() {
+  local case_dir="$1"
+  if [[ -n "${TRAFFIC_PID}" ]]; then
+    echo "continuous traffic is already running" >&2
+    return 1
+  fi
+  TRAFFIC_STOP_FILE="${case_dir}/traffic.stop"
+  TRAFFIC_COUNT_FILE="${case_dir}/traffic-success-count"
+  TRAFFIC_ERROR_FILE="${case_dir}/traffic.error"
+  rm -f "${TRAFFIC_STOP_FILE}" "${TRAFFIC_ERROR_FILE}"
+  printf '0\n' >"${TRAFFIC_COUNT_FILE}"
+  (
+    local count=0 temporary_count="${TRAFFIC_COUNT_FILE}.tmp"
+    while [[ ! -e "${TRAFFIC_STOP_FILE}" ]]; do
+      if ! curl --fail --silent --show-error --max-time 2 -H 'connection: close' \
+        "http://127.0.0.1:${LISTENER_PORT}/soak-traffic-$((count + 1))" >/dev/null; then
+        printf 'continuous traffic curl failed after %s successful requests\n' "${count}" \
+          >"${TRAFFIC_ERROR_FILE}"
+        exit 1
+      fi
+      count=$((count + 1))
+      printf '%s\n' "${count}" >"${temporary_count}"
+      mv "${temporary_count}" "${TRAFFIC_COUNT_FILE}"
+      if (( TRAFFIC_FAIL_AFTER > 0 && count >= TRAFFIC_FAIL_AFTER )); then
+        printf 'injected continuous traffic failure after %s successful requests\n' "${count}" \
+          >"${TRAFFIC_ERROR_FILE}"
+        exit 42
+      fi
+    done
+  ) &
+  TRAFFIC_PID=$!
+}
+assert_continuous_traffic_progress() {
+  local previous="$1" current message deadline=$((SECONDS + 4))
+  while (( SECONDS <= deadline )); do
+    current="$(traffic_success_count)"
+    if (( current > previous )); then
+      printf '%s\n' "${current}"
+      return 0
+    fi
+    if ! kill -0 "${TRAFFIC_PID}" >/dev/null 2>&1; then
+      message=no-error-recorded
+      [[ -s "${TRAFFIC_ERROR_FILE}" ]] && message="$(<"${TRAFFIC_ERROR_FILE}")"
+      echo "continuous traffic exited before making progress: ${message}" >&2
+      return 1
+    fi
+    sleep 0.10
+  done
+  echo "continuous traffic made no progress in 4 seconds (success_count=${current})" >&2
+  return 1
+}
+stop_continuous_traffic() {
+  local case_dir="$1" status=0 final_count message
+  touch "${TRAFFIC_STOP_FILE}"
+  if wait "${TRAFFIC_PID}"; then
+    status=0
+  else
+    status=$?
+  fi
+  TRAFFIC_PID=""
+  final_count="$(traffic_success_count)"
+  if (( status != 0 )) || [[ -s "${TRAFFIC_ERROR_FILE}" ]]; then
+    message=no-error-recorded
+    [[ -s "${TRAFFIC_ERROR_FILE}" ]] && message="$(<"${TRAFFIC_ERROR_FILE}")"
+    echo "continuous traffic failed (status=${status}, success_count=${final_count}): ${message}" >&2
+    return 1
+  fi
+  if (( final_count == 0 )); then
+    echo "continuous traffic stopped without a successful request" >&2
+    return 1
+  fi
+  {
+    echo "stopped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "successful_requests=${final_count}"
+    echo "exit_status=${status}"
+  } >"${case_dir}/traffic-summary.txt"
+  TRAFFIC_STOP_FILE=""
+  TRAFFIC_COUNT_FILE=""
+  TRAFFIC_ERROR_FILE=""
+}
+start_envoy() {
+  local case_dir="$1"
+  mkdir -p "${case_dir}"
+  render_config "${case_dir}/config.yaml"
+  "${ENVOY_BIN}" --mode validate -c "${case_dir}/config.yaml" --log-level error \
+    >"${case_dir}/config-validate.log" 2>&1
+  "${ENVOY_BIN}" -c "${case_dir}/config.yaml" --concurrency "${CONCURRENCY}" \
+    --base-id "${BASE_ID}" --log-level warn --component-log-level wasm:debug \
+    --file-flush-interval-msec 10 \
+    --log-path "${case_dir}/envoy.log" >"${case_dir}/envoy-console.log" 2>&1 &
+  ENVOY_PID=$!
+  for _ in $(seq 1 120); do
+    if curl --fail --silent --max-time 1 \
+      "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null 2>&1; then
+      printf '%s\n' 'timestamp,phase,rss_kb,fd_count,active_vm,rebuild_total,reclaim_latency_count' \
+        >"${case_dir}/resources.csv"
+      return 0
+    fi
+    if ! kill -0 "${ENVOY_PID}" >/dev/null 2>&1; then
+      echo "Envoy exited before ready" >&2
+      cat "${case_dir}/envoy-console.log" >&2 || true
+      return 1
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for Envoy readiness" >&2
+  return 1
+}
+require_response_marker() {
+  local headers="$1" expected_bytes="$2"
+  grep -qi '^HTTP/1.1 200' "${headers}"
+  grep -qi "^x-reclaim-retained-bytes: ${expected_bytes}" "${headers}"
+  grep -Eqi '^x-reclaim-worker-token: [0-9a-f]{16}' "${headers}"
+}
+request() {
+  local case_dir="$1" label="$2" expected_bytes="$3"
+  shift 3
+  curl --fail --silent --show-error --http1.1 --max-time 10 -H 'connection: close' \
+    -H "x-reclaim-request-id: ${label}" "$@" -D "${case_dir}/${label}.headers" \
+    -o "${case_dir}/${label}.body" "http://127.0.0.1:${LISTENER_PORT}/${label}"
+  require_response_marker "${case_dir}/${label}.headers" "${expected_bytes}"
+}
+worker_ids() {
+  local case_dir="$1" request_prefix="$2"
+  find "${case_dir}" -maxdepth 1 -type f -name "${request_prefix}*.headers" \
+    -exec grep -hi '^x-reclaim-worker-token: ' {} + 2>/dev/null |
+    tr -d '\r' | awk -F': ' '{print $2}' | sort -u
+}
+validate_near_oom_memory() {
+  local case_dir="$1" request_prefix="$2" phase="$3" headers token bytes remaining
+  local output="${case_dir}/near-oom-vm-memory.csv" max_bytes=0 min_remaining
+  local -A observed_by_worker=()
+  [[ "${PROFILE}" == near-oom ]] || return 0
+  if [[ ! -f "${output}" ]]; then
+    printf '%s\n' \
+      'phase,worker_token,observed_vm_memory_bytes,threshold_bytes,declared_peak_bytes,vm_limit_bytes,remaining_headroom_bytes,minimum_headroom_bytes' \
+      >"${output}"
+  fi
+  while IFS= read -r -d '' headers; do
+    token="$(tr -d '\r' <"${headers}" |
+      awk -F': ' 'tolower($1) == "x-reclaim-worker-token" {print $2; exit}')"
+    bytes="$(tr -d '\r' <"${headers}" |
+      awk -F': ' 'tolower($1) == "x-reclaim-vm-memory-bytes" {print $2; exit}')"
+    if [[ ! "${token}" =~ ^[0-9a-f]{16}$ || ! "${bytes}" =~ ^[0-9]+$ ]]; then
+      echo "near-OOM response is missing a valid worker token or VM memory observation: ${headers}" >&2
+      return 1
+    fi
+    if [[ -z "${observed_by_worker[${token}]:-}" ]] ||
+      (( bytes > observed_by_worker[${token}] )); then
+      observed_by_worker[${token}]="${bytes}"
+    fi
+  done < <(find "${case_dir}" -maxdepth 1 -type f -name "${request_prefix}*.headers" \
+    -print0 | sort -z)
+  if (( ${#observed_by_worker[@]} < CONCURRENCY )); then
+    echo "near-OOM VM-memory observations covered ${#observed_by_worker[@]} workers, expected ${CONCURRENCY}" >&2
+    return 1
+  fi
+  min_remaining="${DECLARED_VM_LIMIT_BYTES}"
+  for token in "${!observed_by_worker[@]}"; do
+    bytes="${observed_by_worker[${token}]}"
+    remaining=$((DECLARED_VM_LIMIT_BYTES - bytes))
+    if (( bytes < MEMORY_THRESHOLD_BYTES )); then
+      echo "near-OOM observed VM memory ${bytes} did not cross threshold ${MEMORY_THRESHOLD_BYTES}" >&2
+      return 1
+    fi
+    if (( bytes > declared_peak_bytes )); then
+      echo "near-OOM observed VM memory ${bytes} exceeded declared peak ${declared_peak_bytes}" >&2
+      return 1
+    fi
+    if (( remaining < MIN_HEADROOM_BYTES || remaining > MIN_HEADROOM_BYTES * 2 )); then
+      echo "near-OOM observed remaining headroom ${remaining} is outside [${MIN_HEADROOM_BYTES}, $((MIN_HEADROOM_BYTES * 2))]" >&2
+      return 1
+    fi
+    (( bytes > max_bytes )) && max_bytes="${bytes}"
+    (( remaining < min_remaining )) && min_remaining="${remaining}"
+    printf '%s,%s,%s,%s,%s,%s,%s,%s\n' "${phase}" "${token}" "${bytes}" \
+      "${MEMORY_THRESHOLD_BYTES}" "${declared_peak_bytes}" "${DECLARED_VM_LIMIT_BYTES}" \
+      "${remaining}" "${MIN_HEADROOM_BYTES}" >>"${output}"
+  done
+  {
+    echo "near_oom_${phase}_max_observed_vm_memory_bytes=${max_bytes}"
+    echo "near_oom_${phase}_min_observed_headroom_bytes=${min_remaining}"
+  } >>"${case_dir}/manifest.txt"
+}
+live_hold_worker_ids() {
+  local log="$1" request_prefix="$2"
+  awk -v request="request_id=${request_prefix}" '
+    index($0, "holding active request") && index($0, request) {
+      line = $0
+      sub(/^.*worker_token=/, "", line)
+      sub(/ .*/, "", line)
+      print line
+    }
+  ' "${log}" 2>/dev/null | sort -u
+}
+cover_workers() {
+  local case_dir="$1" request_prefix="$2" expected_bytes="$3" trigger="$4" i count
+  for i in $(seq 1 "${STEERING_REQUEST_LIMIT}"); do
+    case "${trigger}" in
+      none) request "${case_dir}" "${request_prefix}-${i}" "${expected_bytes}" ;;
+      explicit) request "${case_dir}" "${request_prefix}-${i}" "${expected_bytes}" \
+        -H 'x-set-rebuild: true' ;;
+      memory) request "${case_dir}" "${request_prefix}-${i}" "${expected_bytes}" \
+        -H "x-alloc-mb: ${MEMORY_TARGET_MB}" ;;
+      *) echo "unknown trigger ${trigger}" >&2; return 2 ;;
+    esac
+    count="$(worker_ids "${case_dir}" "${request_prefix}-" | wc -l)"
+    if (( count >= CONCURRENCY )); then
+      worker_ids "${case_dir}" "${request_prefix}-" \
+        >"${case_dir}/${request_prefix}-workers.txt"
+      return 0
+    fi
+  done
+  echo "failed to steer ${request_prefix} across ${CONCURRENCY} workers" >&2
+  return 1
+}
+start_holds() {
+  local -n hold_pids="$1"
+  local case_dir="$2" request_prefix="$3" trigger="$4" marker_mb="$5"
+  local expected_bytes=$((marker_mb * 1024 * 1024)) i headers body count
+  local minimum_hold_count=$((CONCURRENCY * HOLD_REQUEST_MULTIPLIER))
+  local -a args
+  hold_pids=()
+  for i in $(seq 1 "${STEERING_REQUEST_LIMIT}"); do
+    headers="${case_dir}/${request_prefix}-${i}.headers"
+    body="${case_dir}/${request_prefix}-${i}.body"
+    args=(-H 'connection: close' -H "x-reclaim-request-id: ${request_prefix}-${i}" \
+      -H 'x-hold-active: true' -H "x-hold-delay: ${HOLD_SECONDS}")
+    if [[ "${trigger}" == marker ]]; then
+      args+=(-H "x-alloc-mb: ${marker_mb}")
+    fi
+    curl --fail --silent --show-error --http1.1 --max-time "$((HOLD_SECONDS + 20))" \
+      "${args[@]}" -D "${headers}" -o "${body}" \
+      "http://127.0.0.1:${LISTENER_PORT}/${request_prefix}-${i}" &
+    hold_pids+=("$!")
+    sleep 0.05
+    count="$(live_hold_worker_ids "${case_dir}/envoy.log" "${request_prefix}-" | wc -l)"
+    if (( i >= minimum_hold_count && count >= CONCURRENCY )); then
+      live_hold_worker_ids "${case_dir}/envoy.log" "${request_prefix}-" \
+        >"${case_dir}/${request_prefix}-live-workers.txt"
+      printf '%s\n' "${expected_bytes}" >"${case_dir}/${request_prefix}-expected-bytes"
+      return 0
+    fi
+  done
+  echo "failed to establish held ${request_prefix} Contexts on all ${CONCURRENCY} workers" >&2
+  return 1
+}
+wait_holds() {
+  local -n hold_pids="$1"
+  local case_dir="$2" request_prefix="$3" expected_bytes="$4" index=1 pid
+  for pid in "${hold_pids[@]}"; do
+    if ! wait "${pid}"; then
+      echo "held request ${request_prefix}-${index} failed" >&2
+      return 1
+    fi
+    require_response_marker "${case_dir}/${request_prefix}-${index}.headers" "${expected_bytes}"
+    index=$((index + 1))
+  done
+  if (( $(worker_ids "${case_dir}" "${request_prefix}-" | wc -l) < CONCURRENCY )); then
+    echo "held requests ${request_prefix} did not cover all ${CONCURRENCY} worker plugin instances" >&2
+    return 1
+  fi
+  worker_ids "${case_dir}" "${request_prefix}-" >"${case_dir}/${request_prefix}-workers.txt"
+  hold_pids=()
+}
+assert_holds_alive() {
+  local -n hold_pids="$1"
+  local phase="$2" pid state
+  if (( ${#hold_pids[@]} == 0 )); then
+    echo "${phase}: no held requests remain to prove a live old generation" >&2
+    return 1
+  fi
+  for pid in "${hold_pids[@]}"; do
+    state="$(ps -o stat= -p "${pid}" 2>/dev/null | awk '{print $1}')"
+    if ! kill -0 "${pid}" >/dev/null 2>&1 || [[ -z "${state}" || "${state}" == Z* ]]; then
+      echo "${phase}: held request process ${pid} exited before the guard window completed" >&2
+      return 1
+    fi
+  done
+}
+wait_active_cap() {
+  local baseline="$1" value deadline=$((SECONDS + CUTOVER_DEADLINE_SECONDS))
+  while (( SECONDS <= deadline )); do
+    value="$(stat_value "${active_stat}")"
+    if (( value <= baseline + CONCURRENCY )); then
+      return 0
+    fi
+    sleep 0.20
+  done
+  echo "active generation cap did not settle: baseline=${baseline}, current=${value}, workers=${CONCURRENCY}" >&2
+  return 1
+}
+wait_active_baseline() {
+  local expected="$1" value deadline=$((SECONDS + CUTOVER_DEADLINE_SECONDS))
+  while (( SECONDS <= deadline )); do
+    value="$(stat_value "${active_stat}")"
+    if [[ "${value}" == "${expected}" ]]; then
+      return 0
+    fi
+    sleep 0.20
+  done
+  echo "active VM count did not return to baseline: expected=${expected}, actual=${value}" >&2
+  return 1
+}
+write_manifest() {
+  local case_dir="$1" case_name="$2"
+  {
+    echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "case=${case_name}"
+    echo "profile=${PROFILE}"
+    echo "envoy_bin=${ENVOY_BIN}"
+    echo "envoy_sha256=$(sha256sum "${ENVOY_BIN}" | awk '{print $1}')"
+    echo "envoy_version=$(printf '%s' "${ENVOY_VERSION_OUTPUT}" | tr '\n' ' ')"
+    echo "envoy_binary_commit=${BINARY_ENVOY_HEAD}"
+    echo "envoy_binary_build_state=${BINARY_BUILD_STATE}"
+    echo "envoy_source_repo=${ENVOY_SOURCE_REPO}"
+    echo "envoy_source_commit_verified=${ENVOY_SOURCE_VERIFIED}"
+    echo "config_sha256=$(sha256sum "${case_dir}/config.yaml" | awk '{print $1}')"
+    echo "wasm_sha256=$(sha256sum "${WASM_BINARY}" | awk '{print $1}')"
+    echo "proxy_wasm_cpp_host_commit=${RESOLVED_HOST_PIN}"
+    echo "proxy_wasm_cpp_host_commit_source=${RESOLVED_HOST_PIN_SOURCE}"
+    echo "proxy_wasm_cpp_host_tree=${RESOLVED_HOST_TREE}"
+    echo "proxy_wasm_cpp_host_tree_source=${RESOLVED_HOST_TREE_SOURCE}"
+    echo "concurrency=${CONCURRENCY}"
+    echo "memory_threshold_bytes=${MEMORY_THRESHOLD_BYTES}"
+    echo "memory_target_bytes=${memory_target_bytes}"
+    echo "explicit_marker_bytes=${marker_bytes}"
+    echo "declared_vm_limit_bytes=${DECLARED_VM_LIMIT_BYTES}"
+    echo "declared_vm_overhead_bytes=${DECLARED_VM_OVERHEAD_BYTES}"
+    echo "declared_peak_bytes=${declared_peak_bytes}"
+    echo "minimum_headroom_bytes=${MIN_HEADROOM_BYTES}"
+    echo "vm_limit_provenance=${VM_LIMIT_PROVENANCE:-smoke-budget-not-runtime-limit}"
+    echo "reclaim_latency_semantics=eligible-to-new-current-cutover"
+    echo "rss_semantics=resource-sample-only-no-retirement-claim"
+  } >"${case_dir}/manifest.txt"
+}
+
+run_rolling_case() {
+  local source="$1" current_state="$2" case_name
+  case_name="${source}-${current_state}"
+  local case_dir="${WORKDIR}/${case_name}" marker_mb expected_a_bytes expected_b_bytes
+  local rebuild_before source_before other_before latency_before latency_after_first
+  local guard_rebuild active_baseline final_rebuild expected_final
+  local guard_start_utc guard_end_utc guard_start_ms guard_end_ms guard_elapsed_ms
+  marker_mb="${EXPLICIT_MARKER_MB}"
+  expected_a_bytes=$((marker_mb * 1024 * 1024))
+  expected_b_bytes=0
+  [[ "${source}" == memory ]] && expected_b_bytes="${memory_target_bytes}"
+
+  start_envoy "${case_dir}"
+  write_manifest "${case_dir}" "${case_name}"
+  cover_workers "${case_dir}" baseline 0 none
+  active_baseline="$(stat_value "${active_stat}")"
+  rebuild_before="$(stat_value "${rebuild_stat}")"
+  latency_before="$(latency_count)"
+  if [[ "${source}" == explicit ]]; then
+    source_before="$(stat_value "${explicit_stat}")"
+    other_before="$(stat_value "${memory_stat}")"
+  else
+    source_before="$(stat_value "${memory_stat}")"
+    other_before="$(stat_value "${explicit_stat}")"
+  fi
+  record_resources "${case_dir}" baseline
+
+  # Establish active A Contexts on every worker before making A eligible. This avoids
+  # timer phase skew allowing late held requests to enter B in the N-worker profile.
+  start_holds A_HOLD_PIDS "${case_dir}" A-hold marker "${marker_mb}"
+  cover_workers "${case_dir}" A-eligible \
+    "$([[ "${source}" == memory ]] && echo "${memory_target_bytes}" || echo "${expected_a_bytes}")" \
+    "${source}"
+  if [[ "${source}" == memory ]]; then
+    validate_near_oom_memory "${case_dir}" A-eligible- A_eligible
+  fi
+  wait_stat_at_least "${rebuild_stat}" "$((rebuild_before + CONCURRENCY))"
+  wait_latency_at_least "$((latency_before + CONCURRENCY))"
+  latency_after_first="$(latency_count)"
+  wait_active_cap "${active_baseline}"
+  cover_workers "${case_dir}" B-probe 0 none
+  record_resources "${case_dir}" A-and-B-live
+
+  cover_workers "${case_dir}" B-eligible \
+    "$([[ "${source}" == memory ]] && echo "${memory_target_bytes}" || echo 0)" "${source}"
+  if [[ "${source}" == memory ]]; then
+    validate_near_oom_memory "${case_dir}" B-eligible- B_eligible
+  fi
+  if [[ "${current_state}" == active ]]; then
+    start_holds B_HOLD_PIDS "${case_dir}" B-hold none 0
+  fi
+  guard_rebuild="$(stat_value "${rebuild_stat}")"
+  assert_holds_alive A_HOLD_PIDS guard-start
+  guard_start_utc="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+  guard_start_ms="$(date +%s%3N)"
+  sleep "${GUARD_OBSERVE_SECONDS}"
+  guard_end_ms="$(date +%s%3N)"
+  guard_end_utc="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+  guard_elapsed_ms=$((guard_end_ms - guard_start_ms))
+  assert_holds_alive A_HOLD_PIDS guard-end
+  if (( guard_elapsed_ms < MIN_GUARD_OBSERVE_MS )); then
+    echo "actual live-old guard observation ${guard_elapsed_ms}ms did not cover two 1-second timer intervals" >&2
+    return 1
+  fi
+  {
+    echo "requested_seconds=${GUARD_OBSERVE_SECONDS}"
+    echo "timer_interval_ms=${RECLAIM_TIMER_INTERVAL_MS}"
+    echo "minimum_required_ms=${MIN_GUARD_OBSERVE_MS}"
+    echo "started_at=${guard_start_utc}"
+    echo "ended_at=${guard_end_utc}"
+    echo "elapsed_ms=${guard_elapsed_ms}"
+    echo "held_a_processes=${#A_HOLD_PIDS[@]}"
+  } >"${case_dir}/guard-window.txt"
+  {
+    echo "guard_started_at=${guard_start_utc}"
+    echo "guard_ended_at=${guard_end_utc}"
+    echo "guard_elapsed_ms=${guard_elapsed_ms}"
+  } >>"${case_dir}/manifest.txt"
+  if [[ "$(stat_value "${rebuild_stat}")" != "${guard_rebuild}" ]]; then
+    echo "live A failed to block the B -> C proactive cutover" >&2
+    return 1
+  fi
+  if [[ "$(latency_count)" != "${latency_after_first}" ]]; then
+    echo "live-old skip unexpectedly recorded reclaim latency" >&2
+    return 1
+  fi
+  wait_active_cap "${active_baseline}"
+  record_resources "${case_dir}" live-old-guard
+
+  wait_holds A_HOLD_PIDS "${case_dir}" A-hold "${expected_a_bytes}"
+  expected_final=$((rebuild_before + 2 * CONCURRENCY))
+  wait_stat_at_least "${rebuild_stat}" "${expected_final}"
+  wait_latency_at_least "$((latency_after_first + CONCURRENCY))"
+  cover_workers "${case_dir}" C-probe 0 none
+  final_rebuild="$(stat_value "${rebuild_stat}")"
+  if [[ "${final_rebuild}" != "${expected_final}" ]]; then
+    echo "unexpected successful rebuild count: expected=${expected_final}, actual=${final_rebuild}" >&2
+    return 1
+  fi
+  if [[ "${source}" == explicit ]]; then
+    [[ "$(stat_value "${explicit_stat}")" == "$((source_before + 2 * CONCURRENCY))" ]]
+    [[ "$(stat_value "${memory_stat}")" == "${other_before}" ]]
+  else
+    [[ "$(stat_value "${memory_stat}")" == "$((source_before + 2 * CONCURRENCY))" ]]
+    [[ "$(stat_value "${explicit_stat}")" == "${other_before}" ]]
+  fi
+  [[ "$(stat_value "${recover_stat}")" == 0 ]]
+  wait_active_cap "${active_baseline}"
+  record_resources "${case_dir}" B-to-C-cutover
+
+  if [[ "${current_state}" == active ]]; then
+    wait_holds B_HOLD_PIDS "${case_dir}" B-hold "${expected_b_bytes}"
+  fi
+  wait_active_baseline "${active_baseline}"
+  record_resources "${case_dir}" complete
+  stop_envoy_and_assert_lifecycle "${case_dir}"
+  echo "PASS ${case_name}: active A rolled to B, live A blocked B -> C, then retirement enabled exactly one next cutover"
+}
+
+run_control() {
+  local case_dir="${WORKDIR}/healthy-control" before active_baseline deadline i=0
+  start_envoy "${case_dir}"
+  write_manifest "${case_dir}" healthy-control
+  cover_workers "${case_dir}" control-baseline 0 none
+  before="$(stat_value "${rebuild_stat}")"
+  active_baseline="$(stat_value "${active_stat}")"
+  record_resources "${case_dir}" baseline
+  deadline=$((SECONDS + CONTROL_SECONDS))
+  while (( SECONDS < deadline )); do
+    i=$((i + 1))
+    request "${case_dir}" "control-${i}" 0
+  done
+  [[ "$(stat_value "${rebuild_stat}")" == "${before}" ]]
+  [[ "$(stat_value "${recover_stat}")" == 0 ]]
+  wait_active_baseline "${active_baseline}"
+  record_resources "${case_dir}" complete
+  stop_envoy_and_assert_lifecycle "${case_dir}"
+  echo "PASS healthy-control: sustained requests produced no reclaim/recovery"
+}
+
+run_soak() {
+  local case_dir="${WORKDIR}/rolling-soak" before target rss_before rss_after fd_before fd_after cycle
+  local active_baseline traffic_count
+  start_envoy "${case_dir}"
+  write_manifest "${case_dir}" rolling-soak
+  cover_workers "${case_dir}" soak-baseline 0 none
+  active_baseline="$(stat_value "${active_stat}")"
+  before="$(stat_value "${rebuild_stat}")"
+  rss_before="$(proc_rss_kb)"
+  fd_before="$(proc_fd_count)"
+  start_continuous_traffic "${case_dir}"
+  traffic_count="$(assert_continuous_traffic_progress 0)"
+  for cycle in $(seq 1 "${SOAK_CYCLES}"); do
+    cover_workers "${case_dir}" "soak-trigger-${cycle}" 0 explicit
+    target=$((before + cycle * CONCURRENCY))
+    wait_stat_at_least "${rebuild_stat}" "${target}"
+    if [[ "$(stat_value "${rebuild_stat}")" != "${target}" ]]; then
+      echo "soak cycle ${cycle} created an unbounded generation chain" >&2
+      return 1
+    fi
+    record_resources "${case_dir}" "cycle-${cycle}"
+    sleep 1.10
+    traffic_count="$(assert_continuous_traffic_progress "${traffic_count}")"
+  done
+  stop_continuous_traffic "${case_dir}"
+  rss_after="$(proc_rss_kb)"
+  fd_after="$(proc_fd_count)"
+  if (( rss_after - rss_before > MAX_RSS_GROWTH_KB )); then
+    echo "soak RSS growth exceeded bound: before=${rss_before}, after=${rss_after}, max=${MAX_RSS_GROWTH_KB}" >&2
+    return 1
+  fi
+  if (( fd_after - fd_before > MAX_FD_GROWTH )); then
+    echo "soak FD growth exceeded bound: before=${fd_before}, after=${fd_after}, max=${MAX_FD_GROWTH}" >&2
+    return 1
+  fi
+  wait_active_baseline "${active_baseline}"
+  record_resources "${case_dir}" complete
+  stop_envoy_and_assert_lifecycle "${case_dir}"
+  echo "PASS rolling-soak: ${SOAK_CYCLES} bounded cutovers under continuous traffic; RSS was sampled, not treated as retirement proof"
+}
+
+{
+  echo "profile=${PROFILE}"
+  echo "case=${CASE}"
+  echo "concurrency=${CONCURRENCY}"
+  echo "memory_threshold_bytes=${MEMORY_THRESHOLD_BYTES}"
+  echo "memory_target_bytes=${memory_target_bytes}"
+  echo "explicit_marker_bytes=${marker_bytes}"
+  echo "declared_vm_limit_bytes=${DECLARED_VM_LIMIT_BYTES}"
+  echo "declared_vm_overhead_bytes=${DECLARED_VM_OVERHEAD_BYTES}"
+  echo "declared_peak_bytes=${declared_peak_bytes}"
+  echo "minimum_headroom_bytes=${MIN_HEADROOM_BYTES}"
+  echo "vm_limit_provenance=${VM_LIMIT_PROVENANCE:-smoke-budget-not-runtime-limit}"
+  echo "hold_seconds=${HOLD_SECONDS}"
+  echo "cutover_deadline_seconds=${CUTOVER_DEADLINE_SECONDS}"
+  echo "guard_observe_seconds=${GUARD_OBSERVE_SECONDS}"
+  echo "minimum_guard_observe_ms=${MIN_GUARD_OBSERVE_MS}"
+  echo "hold_request_multiplier=${HOLD_REQUEST_MULTIPLIER}"
+  echo "soak_cycles=${SOAK_CYCLES}"
+  echo "traffic_fail_after=${TRAFFIC_FAIL_AFTER}"
+} >"${WORKDIR}/resolved-parameters.txt"
+
+case "${CASE}" in
+  explicit-idle) run_rolling_case explicit idle ;;
+  memory-active) run_rolling_case memory active ;;
+  control) run_control ;;
+  soak) run_soak ;;
+  all)
+    run_rolling_case explicit idle
+    run_rolling_case memory active
+    run_control
+    run_soak
+    ;;
+esac
+
+trap - EXIT
+cleanup_all
+echo "all requested timer-reclaim checks passed; evidence=${WORKDIR}"

--- a/verification/examples/wasm-vm-reclaim/timer-reclaim/wasm/main.go
+++ b/verification/examples/wasm-vm-reclaim/timer-reclaim/wasm/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+// allocBuffer is retained on the VM (per generation) so linear memory stays
+// high until the generation is reclaimed. A reclaimed (newly cloned) VM starts
+// with an empty buffer, which is exactly the behavior the memory-threshold
+// reclaim experiment observes.
+var allocBuffer []byte
+
+func main() {}
+
+func init() {
+	proxywasm.SetPluginContext(func(contextID uint32) types.PluginContext {
+		return &reclaimPluginContext{contextID: contextID}
+	})
+}
+
+type reclaimPluginContext struct {
+	types.DefaultPluginContext
+	contextID   uint32
+	workerToken string
+}
+
+func (ctx *reclaimPluginContext) OnPluginStart(int) types.OnPluginStartStatus {
+	token := make([]byte, 8)
+	if _, err := rand.Read(token); err != nil {
+		proxywasm.LogCriticalf("reclaim-verify: worker token generation failed: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+	ctx.workerToken = hex.EncodeToString(token)
+	proxywasm.LogDebugf("reclaim-verify: plugin started context_id=%d worker_token=%s",
+		ctx.contextID, ctx.workerToken)
+	return types.OnPluginStartStatusOK
+}
+
+func (ctx *reclaimPluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &reclaimContext{contextID: contextID, workerToken: ctx.workerToken}
+}
+
+type reclaimContext struct {
+	types.DefaultHttpContext
+	contextID    uint32
+	workerToken  string
+	requestID    string
+	retainedSize int
+	vmMemory     uint64
+}
+
+func (ctx *reclaimContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	ctx.requestID, _ = proxywasm.GetHttpRequestHeader("x-reclaim-request-id")
+	if ctx.requestID == "" {
+		ctx.requestID = "unlabeled"
+	}
+
+	// Trigger source 1 (explicit flag): set host-visible shouldRebuild(true).
+	if v, _ := proxywasm.GetHttpRequestHeader("x-set-rebuild"); v == "true" {
+		_ = proxywasm.SetProperty([]string{"wasm_need_rebuild"}, []byte("true"))
+		proxywasm.LogDebugf("reclaim-verify: set wasm_need_rebuild, context_id=%d", ctx.contextID)
+	}
+
+	// Trigger source 2 (memory threshold): ensure the VM retains at least N MiB
+	// and touch every new page so repeated worker-steering requests are idempotent.
+	if v, _ := proxywasm.GetHttpRequestHeader("x-alloc-mb"); v != "" {
+		if mb, err := strconv.Atoi(v); err == nil && mb > 0 {
+			target := mb * 1024 * 1024
+			if target > len(allocBuffer) {
+				previousSize := len(allocBuffer)
+				grown := make([]byte, target)
+				copy(grown, allocBuffer)
+				for i := previousSize; i < len(grown); i += 4096 {
+					grown[i] = 1
+				}
+				allocBuffer = grown
+			}
+			proxywasm.LogDebugf("reclaim-verify: ensured %d MiB, retained total %d MiB, context_id=%d",
+				mb, len(allocBuffer)/(1024*1024), ctx.contextID)
+		}
+	}
+
+	ctx.retainedSize = len(allocBuffer)
+	if data, err := proxywasm.GetProperty([]string{"plugin_vm_memory"}); err == nil && len(data) == 8 {
+		ctx.vmMemory = binary.LittleEndian.Uint64(data)
+		proxywasm.LogDebugf("reclaim-verify: VM memory %d bytes (%.2f MiB), context_id=%d request_id=%s",
+			ctx.vmMemory, float64(ctx.vmMemory)/(1024*1024), ctx.contextID, ctx.requestID)
+	}
+
+	// Holding a stream and making its generation eligible are separate controls.
+	// The harness combines them for the first A -> B cutover and holds B without
+	// implicitly changing the trigger source when checking the live-old guard.
+	if v, _ := proxywasm.GetHttpRequestHeader("x-hold-active"); v == "true" {
+		delay := "6"
+		if requestedDelay, _ := proxywasm.GetHttpRequestHeader("x-hold-delay"); requestedDelay != "" {
+			delay = requestedDelay
+		}
+		proxywasm.LogDebugf("reclaim-verify: holding active request for %ss, context_id=%d request_id=%s retained_bytes=%d worker_token=%s",
+			delay, ctx.contextID, ctx.requestID, ctx.retainedSize, ctx.workerToken)
+		_, err := proxywasm.DispatchHttpCall(
+			"outbound|80||httpbin.dns",
+			[][2]string{
+				{":method", "GET"},
+				{":path", "/slow?delay=" + delay},
+				{":authority", "httpbin.dns"},
+			},
+			nil,
+			nil,
+			30000,
+			func(numHeaders, bodySize, numTrailers int) {
+				proxywasm.LogDebugf("reclaim-verify: hold callback, context_id=%d request_id=%s retained_bytes=%d worker_token=%s",
+					ctx.contextID, ctx.requestID, ctx.retainedSize, ctx.workerToken)
+				if err := proxywasm.ResumeHttpRequest(); err != nil {
+					proxywasm.LogErrorf("reclaim-verify: resume failed: %v", err)
+				}
+			})
+		if err != nil {
+			proxywasm.LogErrorf("reclaim-verify: dispatch hold call failed: %v", err)
+			return types.ActionContinue
+		}
+		return types.ActionPause
+	}
+
+	_ = proxywasm.AddHttpRequestHeader("x-reclaim-verify-plugin", "ok")
+	proxywasm.LogDebugf("reclaim-verify: request passed context_id=%d request_id=%s retained_bytes=%d",
+		ctx.contextID, ctx.requestID, ctx.retainedSize)
+	return types.ActionContinue
+}
+
+func (ctx *reclaimContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
+	_ = proxywasm.AddHttpResponseHeader("x-reclaim-worker-token", ctx.workerToken)
+	_ = proxywasm.AddHttpResponseHeader("x-reclaim-request-id", ctx.requestID)
+	_ = proxywasm.AddHttpResponseHeader("x-reclaim-retained-bytes", strconv.Itoa(ctx.retainedSize))
+	_ = proxywasm.AddHttpResponseHeader("x-reclaim-vm-memory-bytes", strconv.FormatUint(ctx.vmMemory, 10))
+	return types.ActionContinue
+}

--- a/verification/examples/wasm-worker-init-failure/README.md
+++ b/verification/examples/wasm-worker-init-failure/README.md
@@ -1,0 +1,155 @@
+# Request-only worker Wasm initialization recovery
+
+This package verifies the Stage B HTTP behavior after a worker-local Wasm plugin fails to
+initialize. Recovery is request driven: an idle worker does no work, the first later request may
+make an immediate attempt, and later actual attempts for one worker/VM key are separated by a fixed
+one-second guard. There is no initialization timer, backoff sequence, retry cap, or exhausted state.
+
+All runners require an explicit absolute `ENVOY_BIN`; none falls back to a worktree build. The Go
+plugin provides deterministic `configure-reject`, `trap-once`, `trap-always`, and `healthy`
+initialization modes plus the `x-worker-init-request-trap: true` Ready-state trap.
+
+## Functional matrix
+
+Build the plugin once and run the static matrix under both request policies:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static FAIL_OPEN=true CONCURRENCY=4 \
+  WORKDIR=/tmp/wasm-worker-init-static-open \
+  verification/examples/wasm-worker-init-failure/run.sh all
+
+ENVOY_BIN=/absolute/path/to/envoy-static FAIL_OPEN=false CONCURRENCY=4 \
+  WORKDIR=/tmp/wasm-worker-init-static-closed \
+  verification/examples/wasm-worker-init-failure/run.sh all
+```
+
+The runner records the Envoy/Wasm/config hashes, all responses, ordered plugin attempts, relevant
+stats, and host logs. Its Stage B assertions cover:
+
+- `configure-reject` is terminal and never attempts again on later requests;
+- `trap-once` has no idle activity and the request that triggers recovery is itself processed by
+  the recovered plugin (generation and plugin markers are present);
+- `trap-always` has no background activity, immediate requests inside the guard do not invoke the
+  factory, and more than five one-second-separated requests continue to make attempts;
+- `healthy` has no initialization-failure state.
+
+`CONCURRENCY=1` is the most deterministic trace. `CONCURRENCY=4` is the required worker-isolation
+matrix. The N=4 run waits until all worker-local wrappers recover; `RECOVERY_REQUEST_LIMIT` bounds
+connection steering. `FAIL_OPEN=true` bypasses a still-uninitialized wrapper, while
+`FAIL_OPEN=false` returns local 503 until a request successfully initializes that worker.
+
+## Replacement and guard ownership
+
+Run the file-ECDS replacement matrix (N defaults to 4):
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static FAIL_OPEN=true \
+  WORKDIR=/tmp/wasm-worker-init-ecds-open \
+  verification/examples/wasm-worker-init-failure/ecds-replacement/run.sh
+```
+
+It verifies terminal-to-healthy replacement, retryable-to-healthy replacement and gauge drain,
+request-only recovery of a fresh generation, no stale retry after replacement, and failure/healthy
+churn with bounded active VMs, RSS, file descriptors, and `server.memory_allocated`. Configuration
+updates retain the same Wasm bytes and VM key; only plugin configuration/generation changes.
+
+The common unit tests provide the exact same-key/different-key guard matrix, including a no-handle
+entry surviving cross-key registry sweeping. The static and ECDS N=4 runs provide the real-worker
+evidence; line-level guard ownership is therefore tested without relying on scheduler timing.
+
+## Ready recovery
+
+The existing request-stage runner verifies the Ready-state `rebuild(true)` path and the shared fixed
+guard for more than five cycles:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static CYCLES=6 \
+  WORKDIR=/tmp/wasm-worker-init-request-recovery \
+  verification/examples/wasm-worker-init-failure/request-recovery/run.sh
+```
+
+Each cycle traps in `OnHttpRequestHeaders`, waits beyond the one-second guard, and confirms that the
+next normal request rebuilds the VM. Worker-initialization retry counters remain unchanged.
+
+## Time-series soak
+
+`soak/run.sh` produces 10-second CSV samples and 5-minute window summaries for initialization
+recovery (`trap-once` generations), Ready recovery (request traps), persistent initialization
+failure (`trap-always`), and a paired healthy control using the same Envoy binary, request rate,
+worker count, and ECDS update cadence.
+
+Smoke example:
+
+```bash
+ENVOY_BIN=/absolute/path/to/envoy-static PROFILE=smoke SCENARIO=initialization \
+  WORKDIR=/tmp/wasm-worker-init-soak-init \
+  verification/examples/wasm-worker-init-failure/soak/run.sh
+```
+
+Formal defaults are deliberately declared before the run starts:
+
+- one repetition per scenario and paired healthy control, with mandatory `CONCURRENCY=4`;
+- 300-second warm-up, then 900 measured seconds;
+- at least 1000 recoveries for `initialization`, at least 600 recoveries for `ready`, and at least
+  600 actual attempts for `persistent`;
+- each Ready recovery request starts at least 1050 ms after its trap response; crash-counter
+  observation runs inside that deadline rather than extending the round after the guard wait;
+- 10-second samples and non-overlapping 300-second windows;
+- final-vs-first window median growth: FD <= 8, threads <= 0, allocated and heap memory <= 32 MiB,
+  and RSS/RssAnon/Pss/Private_Dirty <= 64 MiB;
+- per-100-event median trend: allocated and heap memory <= 1 MiB and
+  RSS/RssAnon/Pss/Private_Dirty <= 4 MiB;
+- the paired healthy control must satisfy the same absolute bounds.
+- recovery-minus-control stable-window growth is additionally limited to FD <= 4, threads <= 0,
+  allocated and heap memory <= 16 MiB, and RSS/RssAnon/Pss/Private_Dirty <= 32 MiB; its relative
+  trend is limited to 512 KiB and 2 MiB per 100 events respectively.
+
+Growth uses the median of up to the first two versus last two fixed windows; the three-window formal
+profile uses the first and last window. Trend uses least-squares over all fixed-window medians and
+each run's own event sequence, normalized per 100 events. Formal
+sampling begins only after the full 300-second warm-up; warm-up data is intentionally excluded from
+`samples.csv`. Actual and control runs each append exactly one `elapsed=duration` terminal sample;
+the event-count gate reads that row, while fixed resource windows continue to use only samples
+strictly inside the measured duration. The two-window smoke profile checks absolute and paired
+growth but does not use its single edge-to-edge segment as a per-100-event regression; the formal
+profile has at least three windows and enforces the trend bounds.
+
+Each initialization generation recovers all four workers, checks every counter-changing response
+for the same generation marker, and returns the worker gauge to zero. Because `trap-once` also
+fails the neutral main-thread TLS slot, actual runs stabilize at one active VM below their healthy
+baseline; healthy controls remain at that baseline. Both values are asserted in every measured
+sample. Its control performs the same ECDS update and fixed request burst. Each Ready
+round sends one trap and asserts `crash_total + 1`, then adaptively scans with normal requests (cap
+200) until exact `recover_total + 1`; the counter-changing response carries the marker. The actual
+run anchors the 1050 ms deadline after the trap response, performs crash-counter observation inside
+that wait, and records each recovery request's guard elapsed time. A request below the declared
+guard fails immediately. Exact admin-stat filters avoid serializing the complete stats set for each
+counter read, and each post-request recovery counter becomes the next request's baseline instead of
+being fetched twice. This keeps observational admin work off the Ready critical path where
+possible. The run also records every round offset, phase, scan count, recovery latency, and
+per-request offset. Its healthy control validates the complete schedule and replays the same round
+timing, request count, and per-request cadence; missing or misaligned schedule data fails closed.
+Ready also keeps zero `recover_error`, leaves initialization counters unchanged, and returns to
+baseline active VMs.
+Persistent rounds send a fixed high-QPS burst and record the actual
+retry delta and timestamp in `attempt-rate.csv`, enforce at most N attempts per guard window, retain
+gauge N, and retain the run-local active VM baseline; its healthy control retains gauge zero and
+its own active baseline. Every measured sample is checked against the scenario's expected gauge and
+active values. `server.memory_heap_size` is sampled when Envoy exposes it; otherwise it is recorded
+as `-1` and excluded from that metric's gates.
+
+Run a formal campaign with `PROFILE=formal SCENARIO=all CONCURRENCY=4`. Every threshold, resolved
+parameter, binary hash, config hash, raw CSV, and window summary remains under `WORKDIR`. The
+analysis fails closed if fewer events than declared are observed or if `/proc`/admin samples are
+missing.
+
+## Adjacent regressions
+
+- `verification/examples/wasm-vm-reclaim/ecds-file-update/run.sh` covers binary A/B changes,
+  in-flight request isolation, proactive rebuild, and reclaim.
+- `test/extensions/common/wasm/wasm_test.cc` covers the shared rebuild guard, no-handle cleanup,
+  replacement state ownership, terminal classification, and the no-cap request sequence.
+- `verification/examples/wasm-canary-skip/` isolates identical-filter canary de-duplication.
+
+Keep these adjacent regressions in the final evidence set; they exercise different ownership edges
+and are intentionally not copied into this directory.

--- a/verification/examples/wasm-worker-init-failure/config.yaml.template
+++ b/verification/examples/wasm-worker-init-failure/config.yaml.template
@@ -1,0 +1,60 @@
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: __ADMIN_PORT__
+
+static_resources:
+  listeners:
+  - name: worker_init_repro
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: __LISTENER_PORT__
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: worker_init_repro
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: {prefix: "/"}
+                route: {cluster: repro_upstream}
+          http_filters:
+          - name: envoy.filters.http.wasm
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+              config:
+                name: worker_init_repro
+                root_id: worker_init_repro
+                fail_open: __FAIL_OPEN__
+                vm_config:
+                  vm_id: worker_init_repro
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: "__WASM_BINARY__"
+                configuration:
+                  "@type": type.googleapis.com/google.protobuf.StringValue
+                  value: '{"mode":"__MODE__","run_id":"__RUN_ID__","worker_count":__WORKER_COUNT__,"generation":"__GENERATION__"}'
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: repro_upstream
+    connect_timeout: 1s
+    type: STATIC
+    load_assignment:
+      cluster_name: repro_upstream
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: __UPSTREAM_PORT__

--- a/verification/examples/wasm-worker-init-failure/ecds-replacement/config.yaml.template
+++ b/verification/examples/wasm-worker-init-failure/ecds-replacement/config.yaml.template
@@ -1,0 +1,29 @@
+node:
+  cluster: worker-init-ecds
+  id: worker-init-ecds
+
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: __ADMIN_PORT__
+
+dynamic_resources:
+  lds_config:
+    resource_api_version: V3
+    path: __WORKDIR__/lds.yaml
+
+static_resources:
+  clusters:
+  - name: repro_upstream
+    connect_timeout: 1s
+    type: STATIC
+    load_assignment:
+      cluster_name: repro_upstream
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: __UPSTREAM_PORT__

--- a/verification/examples/wasm-worker-init-failure/ecds-replacement/ecds.yaml.template
+++ b/verification/examples/wasm-worker-init-failure/ecds-replacement/ecds.yaml.template
@@ -1,0 +1,21 @@
+resources:
+- "@type": type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig
+  name: worker_init_repro_filter
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+    value:
+      config:
+        name: worker_init_repro
+        root_id: worker_init_repro
+        fail_open: __FAIL_OPEN__
+        vm_config:
+          vm_id: worker_init_repro
+          runtime: envoy.wasm.runtime.v8
+          code:
+            local:
+              filename: "__WASM_BINARY__"
+          allow_precompiled: true
+        configuration:
+          "@type": type.googleapis.com/google.protobuf.StringValue
+          value: '{"mode":"__MODE__","run_id":"__RUN_ID__","worker_count":__WORKER_COUNT__,"generation":"__GENERATION__"}'

--- a/verification/examples/wasm-worker-init-failure/ecds-replacement/lds.yaml.template
+++ b/verification/examples/wasm-worker-init-failure/ecds-replacement/lds.yaml.template
@@ -1,0 +1,36 @@
+resources:
+- "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+  name: worker_init_ecds_listener
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: __LISTENER_PORT__
+  filter_chains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        stat_prefix: worker_init_ecds
+        route_config:
+          name: local_route
+          virtual_hosts:
+          - name: local_service
+            domains: ["*"]
+            routes:
+            - match: {prefix: "/"}
+              route: {cluster: repro_upstream}
+        http_filters:
+        - name: worker_init_repro_filter
+          config_discovery:
+            config_source:
+              path: __WORKDIR__/ecds.yaml
+              resource_api_version: V3
+            apply_default_config_without_warming: true
+            default_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            type_urls:
+            - type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            - type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+        - name: envoy.filters.http.router
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/verification/examples/wasm-worker-init-failure/ecds-replacement/run.sh
+++ b/verification/examples/wasm-worker-init-failure/ecds-replacement/run.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENVOY_BIN="${ENVOY_BIN:-}"
+WASM_BINARY="${WASM_BINARY:-}"
+WORKDIR="${WORKDIR:-/tmp/wasm-worker-init-ecds-replacement}"
+LISTENER_PORT="${LISTENER_PORT:-10005}"
+ADMIN_PORT="${ADMIN_PORT:-9908}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3085}"
+BASE_ID="${BASE_ID:-123}"
+CONCURRENCY="${CONCURRENCY:-4}"
+FAIL_OPEN="${FAIL_OPEN:-true}"
+IDLE_SECONDS="${IDLE_SECONDS:-10}"
+GUARD_WAIT_SECONDS="${GUARD_WAIT_SECONDS:-1.10}"
+RECOVERY_REQUEST_LIMIT="${RECOVERY_REQUEST_LIMIT:-400}"
+CHURN_CYCLES="${CHURN_CYCLES:-6}"
+MAX_RSS_GROWTH_KB="${MAX_RSS_GROWTH_KB:-262144}"
+MAX_FD_GROWTH="${MAX_FD_GROWTH:-8}"
+MAX_SERVER_MEMORY_GROWTH_BYTES="${MAX_SERVER_MEMORY_GROWTH_BYTES:-268435456}"
+WORKDIR_MARKER=.envoy-verification-workdir
+ENVOY_PID=""
+UPSTREAM_PID=""
+
+if [[ -z "${ENVOY_BIN}" || "${ENVOY_BIN}" != /* || ! -x "${ENVOY_BIN}" ]]; then
+  echo "ENVOY_BIN must explicitly name an absolute executable Envoy binary" >&2
+  exit 1
+fi
+if [[ "${FAIL_OPEN}" != true && "${FAIL_OPEN}" != false ]]; then
+  echo "FAIL_OPEN must be true or false" >&2
+  exit 2
+fi
+for pair in "CONCURRENCY:${CONCURRENCY}" "IDLE_SECONDS:${IDLE_SECONDS}" \
+  "RECOVERY_REQUEST_LIMIT:${RECOVERY_REQUEST_LIMIT}" "CHURN_CYCLES:${CHURN_CYCLES}"; do
+  name="${pair%%:*}"; value="${pair#*:}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || { echo "${name} must be positive" >&2; exit 2; }
+done
+
+tmp_root="$(realpath -m /tmp)"
+WORKDIR="$(realpath -m "${WORKDIR}")"
+case "${WORKDIR}" in "${tmp_root}"/?*) ;; *) echo "WORKDIR must be below /tmp" >&2; exit 1;; esac
+if [[ -d "${WORKDIR}" && ! -f "${WORKDIR}/${WORKDIR_MARKER}" ]] &&
+  find "${WORKDIR}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "refusing to clean unmarked non-empty WORKDIR: ${WORKDIR}" >&2
+  exit 1
+fi
+mkdir -p "${WORKDIR}"
+touch "${WORKDIR}/${WORKDIR_MARKER}"
+find "${WORKDIR}" -mindepth 1 -depth ! -path "${WORKDIR}/${WORKDIR_MARKER}" -delete
+
+cleanup() {
+  if [[ -n "${ENVOY_PID}" ]]; then kill "${ENVOY_PID}" >/dev/null 2>&1 || true; wait "${ENVOY_PID}" >/dev/null 2>&1 || true; fi
+  if [[ -n "${UPSTREAM_PID}" ]]; then kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true; wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true; fi
+}
+trap cleanup EXIT
+
+if [[ -n "${WASM_BINARY}" ]]; then
+  [[ "${WASM_BINARY}" == /* && -f "${WASM_BINARY}" ]] || { echo "invalid WASM_BINARY" >&2; exit 1; }
+else
+  WASM_BINARY="${WORKDIR}/worker-init-repro.wasm"
+  (cd "${PARENT_DIR}/wasm" && GOWORK=off GOOS=wasip1 GOARCH=wasm \
+    go build -buildmode=c-shared -o "${WASM_BINARY}" .)
+fi
+
+sed -e "s#__ADMIN_PORT__#${ADMIN_PORT}#g" -e "s#__UPSTREAM_PORT__#${UPSTREAM_PORT}#g" \
+  -e "s#__WORKDIR__#${WORKDIR}#g" "${SCRIPT_DIR}/config.yaml.template" \
+  >"${WORKDIR}/config.yaml"
+sed -e "s#__LISTENER_PORT__#${LISTENER_PORT}#g" -e "s#__WORKDIR__#${WORKDIR}#g" \
+  "${SCRIPT_DIR}/lds.yaml.template" >"${WORKDIR}/lds.yaml"
+
+install_generation() {
+  local mode="$1" generation="$2" run_id="$3"
+  local next="${WORKDIR}/ecds.yaml.next"
+  sed -e "s#__FAIL_OPEN__#${FAIL_OPEN}#g" -e "s#__WASM_BINARY__#${WASM_BINARY}#g" \
+    -e "s#__MODE__#${mode}#g" -e "s#__RUN_ID__#${run_id}#g" \
+    -e "s#__WORKER_COUNT__#${CONCURRENCY}#g" -e "s#__GENERATION__#${generation}#g" \
+    "${SCRIPT_DIR}/ecds.yaml.template" >"${next}"
+  mv "${next}" "${WORKDIR}/ecds.yaml"
+  printf '%s,%s,%s,%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${mode}" "${generation}" \
+    "$(sha256sum "${WORKDIR}/ecds.yaml" | awk '{print $1}')" >>"${WORKDIR}/updates.csv"
+}
+
+prefix=wasm.envoy.wasm.runtime.v8.plugin.worker_init_repro
+retryable_stat="${prefix}.worker_init_retryable_failure_total"
+terminal_stat="${prefix}.worker_init_terminal_failure_total"
+retry_stat="${prefix}.worker_init_retry_total"
+recovered_stat="${prefix}.worker_init_recovered_total"
+uninitialized_stat="${prefix}.worker_uninitialized"
+active_stat=wasm.envoy.wasm.runtime.v8.active
+stat_value() {
+  local stat="$1"
+  curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${ADMIN_PORT}/stats" |
+    awk -F': ' -v stat="${stat}" '$1 == stat {print $2; found=1} END {if (!found) print 0}'
+}
+wait_stat_eq() {
+  local stat="$1" expected="$2" value=0
+  for _ in $(seq 1 200); do
+    value="$(stat_value "${stat}")"
+    [[ "${value}" == "${expected}" ]] && return 0
+    sleep 0.25
+  done
+  echo "timed out waiting for ${stat}=${expected}; last=${value}" >&2
+  return 1
+}
+wait_active_baseline() {
+  local stage="$1" value=0 poll
+  for poll in $(seq 1 200); do
+    value="$(stat_value "${active_stat}")"
+    printf '%s,%s,%s,%s,%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${stage}" "${poll}" \
+      "${active_baseline}" "${value}" >>"${WORKDIR}/active-baseline.csv"
+    [[ "${value}" == "${active_baseline}" ]] && return 0
+    sleep 0.25
+  done
+  echo "timed out waiting for ${stage} active=${active_baseline}; last=${value}" >&2
+  return 1
+}
+wait_generation() {
+  local generation="$1"
+  for i in $(seq 1 "${RECOVERY_REQUEST_LIMIT}"); do
+    request "generation-${generation}-${i}"
+    if [[ "$(<"${WORKDIR}/generation-${generation}-${i}.status")" == 200 ]] &&
+      grep -qi "^x-worker-init-generation: ${generation}" \
+        "${WORKDIR}/generation-${generation}-${i}.headers"; then
+      return 0
+    fi
+  done
+  echo "did not observe generation ${generation}" >&2
+  return 1
+}
+request() {
+  local label="$1"
+  curl --silent --show-error --max-time 5 -H 'connection: close' \
+    -D "${WORKDIR}/${label}.headers" -o "${WORKDIR}/${label}.body" -w '%{http_code}' \
+    "http://127.0.0.1:${LISTENER_PORT}/${label}" >"${WORKDIR}/${label}.status" || true
+}
+require_failure_policy() {
+  local label="$1"
+  request "${label}"
+  if [[ "${FAIL_OPEN}" == true ]]; then
+    [[ "$(<"${WORKDIR}/${label}.status")" == 200 ]] &&
+      grep -qi '^x-upstream-marker: reached' "${WORKDIR}/${label}.headers" &&
+      grep -qi '^x-plugin-marker: absent' "${WORKDIR}/${label}.headers"
+  else
+    [[ "$(<"${WORKDIR}/${label}.status")" == 503 ]] &&
+      ! grep -qi '^x-upstream-marker:' "${WORKDIR}/${label}.headers"
+  fi
+}
+proc_rss_kb() { awk '/VmRSS:/ {print $2}' "/proc/${ENVOY_PID}/status"; }
+proc_fd_count() { find "/proc/${ENVOY_PID}/fd" -maxdepth 1 -type l | wc -l; }
+require_growth_max() {
+  local label="$1" before="$2" after="$3" maximum="$4"
+  (( after - before <= maximum )) || { echo "${label} growth exceeded ${maximum}" >&2; return 1; }
+}
+
+printf 'timestamp_utc,mode,generation,config_sha256\n' >"${WORKDIR}/updates.csv"
+install_generation configure-reject terminal-old terminal-old
+"${ENVOY_BIN}" --mode validate -c "${WORKDIR}/config.yaml" --log-level error \
+  >"${WORKDIR}/validate.log" 2>&1
+UPSTREAM_PORT="${UPSTREAM_PORT}" python3 "${PARENT_DIR}/upstream_server.py" \
+  >"${WORKDIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+for _ in $(seq 1 80); do
+  curl --fail --silent --max-time 1 "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+"${ENVOY_BIN}" -c "${WORKDIR}/config.yaml" --concurrency "${CONCURRENCY}" \
+  --base-id "${BASE_ID}" --log-level warn --component-log-level wasm:debug,config:debug \
+  --log-path "${WORKDIR}/envoy.log" >"${WORKDIR}/console.log" 2>&1 &
+ENVOY_PID=$!
+for _ in $(seq 1 120); do
+  if kill -0 "${ENVOY_PID}" >/dev/null 2>&1 &&
+    curl --fail --silent --max-time 1 "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null
+
+# Terminal state never retries; replacement owns and drains the old wrapper-local gauge.
+wait_stat_eq "${terminal_stat}" "${CONCURRENCY}"
+wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+terminal_retry="$(stat_value "${retry_stat}")"
+require_failure_policy terminal-old
+sleep "${IDLE_SECONDS}"
+require_failure_policy terminal-old-after-idle
+[[ "$(stat_value "${retry_stat}")" == "${terminal_retry}" ]]
+install_generation healthy terminal-healthy terminal-healthy
+wait_generation terminal-healthy
+wait_stat_eq "${uninitialized_stat}" 0
+active_baseline="$(stat_value "${active_stat}")"
+printf 'timestamp_utc,stage,poll,expected_active,actual_active\n' \
+  >"${WORKDIR}/active-baseline.csv"
+printf '%s,%s,%s,%s,%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" baseline-established 0 \
+  "${active_baseline}" "${active_baseline}" >>"${WORKDIR}/active-baseline.csv"
+
+# A fresh retryable generation is idle until requests. Every counter-changing request must carry
+# that same generation's marker, proving recovery precedes normal processing of that request.
+retryable_before="$(stat_value "${retryable_stat}")"
+retry_before="$(stat_value "${retry_stat}")"
+recovered_before="$(stat_value "${recovered_stat}")"
+install_generation trap-once request-recovery request-recovery
+wait_stat_eq "${retryable_stat}" "$((retryable_before + CONCURRENCY))"
+wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+sleep "${IDLE_SECONDS}"
+[[ "$(stat_value "${retry_stat}")" == "${retry_before}" ]]
+recovered="${recovered_before}"
+for i in $(seq 1 "${RECOVERY_REQUEST_LIMIT}"); do
+  before="${recovered}"
+  request "request-recovery-${i}"
+  recovered="$(stat_value "${recovered_stat}")"
+  if (( recovered > before )); then
+    [[ "$(<"${WORKDIR}/request-recovery-${i}.status")" == 200 ]]
+    grep -qi '^x-plugin-marker: ready' "${WORKDIR}/request-recovery-${i}.headers"
+    grep -qi '^x-worker-init-generation: request-recovery' \
+      "${WORKDIR}/request-recovery-${i}.headers"
+  fi
+  (( recovered == recovered_before + CONCURRENCY )) && break
+done
+[[ "${recovered}" == "$((recovered_before + CONCURRENCY))" ]]
+wait_stat_eq "${uninitialized_stat}" 0
+
+# Replace a persistent failed generation before the guard opens. With no background timer, waiting
+# past the old deadline cannot mutate counters or resurrect the replaced wrapper.
+retryable_before="$(stat_value "${retryable_stat}")"
+retry_before="$(stat_value "${retry_stat}")"
+install_generation trap-always persistent-old persistent-old
+wait_stat_eq "${retryable_stat}" "$((retryable_before + CONCURRENCY))"
+wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+require_failure_policy persistent-old
+retry_after_request="$(stat_value "${retry_stat}")"
+[[ "${retry_after_request}" == "${retry_before}" ]]
+install_generation healthy replacement-healthy replacement-healthy
+wait_generation replacement-healthy
+wait_stat_eq "${uninitialized_stat}" 0
+wait_active_baseline persistent-replacement
+sleep "${GUARD_WAIT_SECONDS}"
+[[ "$(stat_value "${retry_stat}")" == "${retry_after_request}" ]]
+
+# Repeat replacement/drain ownership while retaining bounded process resources.
+rss_before="$(proc_rss_kb)"
+fd_before="$(proc_fd_count)"
+memory_before="$(stat_value server.memory_allocated)"
+terminal_before="$(stat_value "${terminal_stat}")"
+for cycle in $(seq 1 "${CHURN_CYCLES}"); do
+  install_generation configure-reject "churn-failed-${cycle}" "churn-failed-${cycle}"
+  wait_stat_eq "${terminal_stat}" "$((terminal_before + cycle * CONCURRENCY))"
+  wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+  require_failure_policy "churn-failed-${cycle}"
+  install_generation healthy "churn-healthy-${cycle}" "churn-healthy-${cycle}"
+  wait_generation "churn-healthy-${cycle}"
+  wait_stat_eq "${uninitialized_stat}" 0
+  wait_active_baseline "churn-healthy-${cycle}"
+done
+sleep 2
+wait_active_baseline churn-final
+rss_after="$(proc_rss_kb)"
+fd_after="$(proc_fd_count)"
+memory_after="$(stat_value server.memory_allocated)"
+require_growth_max VmRSS-kB "${rss_before}" "${rss_after}" "${MAX_RSS_GROWTH_KB}"
+require_growth_max fd "${fd_before}" "${fd_after}" "${MAX_FD_GROWTH}"
+require_growth_max server.memory_allocated "${memory_before}" "${memory_after}" \
+  "${MAX_SERVER_MEMORY_GROWTH_BYTES}"
+
+{
+  echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "envoy_bin=${ENVOY_BIN}"
+  echo "envoy_sha256=$(sha256sum "${ENVOY_BIN}" | awk '{print $1}')"
+  echo "wasm_sha256=$(sha256sum "${WASM_BINARY}" | awk '{print $1}')"
+  echo "fail_open=${FAIL_OPEN}"
+  echo "concurrency=${CONCURRENCY}"
+  echo "idle_seconds=${IDLE_SECONDS}"
+  echo "worker_init_retryable_failure_total=$(stat_value "${retryable_stat}")"
+  echo "worker_init_terminal_failure_total=$(stat_value "${terminal_stat}")"
+  echo "worker_init_retry_total=$(stat_value "${retry_stat}")"
+  echo "worker_init_recovered_total=$(stat_value "${recovered_stat}")"
+  echo "worker_uninitialized=$(stat_value "${uninitialized_stat}")"
+  echo "active_baseline=${active_baseline}"
+  echo "active_final=$(stat_value "${active_stat}")"
+  echo "active_baseline_evidence=active-baseline.csv"
+  echo "active_baseline_poll_samples=$(awk 'END { print NR - 1 }' "${WORKDIR}/active-baseline.csv")"
+  echo "active_baseline_summary=$(awk -F, '
+    NR > 1 {
+      if (!seen[$2]++) order[++count] = $2
+      last[$2] = $5
+    }
+    END {
+      for (i = 1; i <= count; ++i) {
+        if (i > 1) printf ";"
+        printf "%s=%s", order[i], last[order[i]]
+      }
+    }
+  ' "${WORKDIR}/active-baseline.csv")"
+  echo "rss_kb=${rss_before}->${rss_after}"
+  echo "fd_count=${fd_before}->${fd_after}"
+  echo "server_memory_allocated=${memory_before}->${memory_after}"
+} | tee "${WORKDIR}/evidence.txt"
+
+kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+ENVOY_PID=""
+grep -q '~Wasm 0 remaining active' "${WORKDIR}/console.log"
+grep 'worker-init-repro: plugin start' "${WORKDIR}/envoy.log" >"${WORKDIR}/attempts.log"
+cleanup
+trap - EXIT
+echo "evidence: ${WORKDIR}/evidence.txt"
+echo PASS

--- a/verification/examples/wasm-worker-init-failure/request-recovery/run.sh
+++ b/verification/examples/wasm-worker-init-failure/request-recovery/run.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENVOY_BIN="${ENVOY_BIN:-}"
+WASM_BINARY="${WASM_BINARY:-}"
+WORKDIR="${WORKDIR:-/tmp/wasm-worker-init-request-recovery}"
+LISTENER_PORT="${LISTENER_PORT:-10006}"
+ADMIN_PORT="${ADMIN_PORT:-9909}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3086}"
+BASE_ID="${BASE_ID:-125}"
+CYCLES="${CYCLES:-6}"
+RECOVERY_WAIT_SECONDS="${RECOVERY_WAIT_SECONDS:-1.25}"
+MAX_RSS_GROWTH_KB="${MAX_RSS_GROWTH_KB:-262144}"
+MAX_FD_GROWTH="${MAX_FD_GROWTH:-8}"
+MAX_SERVER_MEMORY_GROWTH_BYTES="${MAX_SERVER_MEMORY_GROWTH_BYTES:-268435456}"
+WORKDIR_MARKER=".envoy-verification-workdir"
+ENVOY_PID=""
+UPSTREAM_PID=""
+
+if [[ -z "${ENVOY_BIN}" || "${ENVOY_BIN}" != /* || ! -x "${ENVOY_BIN}" ]]; then
+  echo "ENVOY_BIN must explicitly name an absolute executable Envoy binary" >&2
+  exit 1
+fi
+if [[ ! "${CYCLES}" =~ ^[1-9][0-9]*$ || "${CYCLES}" -lt 6 ]]; then
+  echo "CYCLES must be an integer of at least 6 to cross the former retry-cap boundary" >&2
+  exit 2
+fi
+
+TMP_ROOT="$(realpath -m /tmp)"
+WORKDIR="$(realpath -m "${WORKDIR}")"
+case "${WORKDIR}" in
+  "${TMP_ROOT}"/?*) ;;
+  *)
+    echo "WORKDIR must resolve to a dedicated directory below ${TMP_ROOT}: ${WORKDIR}" >&2
+    exit 1
+    ;;
+esac
+if [[ -d "${WORKDIR}" && ! -f "${WORKDIR}/${WORKDIR_MARKER}" ]] &&
+  find "${WORKDIR}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "refusing to clean unmarked non-empty WORKDIR: ${WORKDIR}" >&2
+  exit 1
+fi
+mkdir -p "${WORKDIR}"
+touch "${WORKDIR}/${WORKDIR_MARKER}"
+find "${WORKDIR}" -mindepth 1 -depth ! -path "${WORKDIR}/${WORKDIR_MARKER}" -delete
+
+cleanup_envoy() {
+  if [[ -n "${ENVOY_PID}" ]]; then
+    kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+    wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+    ENVOY_PID=""
+  fi
+}
+
+cleanup_upstream() {
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    UPSTREAM_PID=""
+  fi
+}
+
+cleanup_all() {
+  cleanup_envoy
+  cleanup_upstream
+}
+trap cleanup_all EXIT
+
+if [[ -n "${WASM_BINARY}" ]]; then
+  if [[ "${WASM_BINARY}" != /* || ! -f "${WASM_BINARY}" ]]; then
+    echo "WASM_BINARY must name an absolute existing file when provided" >&2
+    exit 1
+  fi
+else
+  WASM_BINARY="${WORKDIR}/worker-init-repro.wasm"
+  (cd "${PARENT_DIR}/wasm" && GOWORK=off GOOS=wasip1 GOARCH=wasm \
+    go build -buildmode=c-shared -o "${WASM_BINARY}" .)
+fi
+
+sed \
+  -e "s#__ADMIN_PORT__#${ADMIN_PORT}#g" \
+  -e "s#__LISTENER_PORT__#${LISTENER_PORT}#g" \
+  -e "s#__UPSTREAM_PORT__#${UPSTREAM_PORT}#g" \
+  -e "s#__FAIL_OPEN__#true#g" \
+  -e "s#__WASM_BINARY__#${WASM_BINARY}#g" \
+  -e "s#__MODE__#healthy#g" \
+  -e "s#__RUN_ID__#request-recovery#g" \
+  -e "s#__WORKER_COUNT__#1#g" \
+  -e "s#__GENERATION__#request-recovery#g" \
+  "${PARENT_DIR}/config.yaml.template" >"${WORKDIR}/config.yaml"
+
+"${ENVOY_BIN}" --mode validate -c "${WORKDIR}/config.yaml" --log-level error \
+  >"${WORKDIR}/validate.log" 2>&1
+
+UPSTREAM_PORT="${UPSTREAM_PORT}" python3 "${PARENT_DIR}/upstream_server.py" \
+  >"${WORKDIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+upstream_ready=false
+for _ in $(seq 1 40); do
+  if curl --fail --silent --show-error --max-time 1 \
+    "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null 2>&1; then
+    upstream_ready=true
+    break
+  fi
+  sleep 0.25
+done
+if [[ "${upstream_ready}" != "true" ]]; then
+  echo "timed out waiting for upstream" >&2
+  exit 1
+fi
+
+"${ENVOY_BIN}" -c "${WORKDIR}/config.yaml" --concurrency 1 --base-id "${BASE_ID}" \
+  --log-level warn --component-log-level wasm:debug \
+  --log-path "${WORKDIR}/envoy.log" >"${WORKDIR}/console.log" 2>&1 &
+ENVOY_PID=$!
+envoy_ready=false
+for _ in $(seq 1 80); do
+  if kill -0 "${ENVOY_PID}" >/dev/null 2>&1 &&
+    curl --fail --silent --show-error --max-time 1 \
+      "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null 2>&1; then
+    envoy_ready=true
+    break
+  fi
+  sleep 0.25
+done
+if [[ "${envoy_ready}" != "true" ]]; then
+  echo "timed out waiting for Envoy" >&2
+  exit 1
+fi
+
+stat_value() {
+  local stat="$1"
+  curl --fail --silent --show-error --max-time 2 \
+    "http://127.0.0.1:${ADMIN_PORT}/stats" | \
+    awk -F': ' -v stat="${stat}" '$1 == stat { print $2; found=1 } END { if (!found) print 0 }'
+}
+
+wait_stat_eq() {
+  local stat="$1"
+  local expected="$2"
+  local value=0
+  for _ in $(seq 1 80); do
+    value="$(stat_value "${stat}")"
+    if [[ "${value}" == "${expected}" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for ${stat}=${expected}; last value=${value}" >&2
+  return 1
+}
+
+wait_active_at_most() {
+  local maximum="$1"
+  local value=0
+  for _ in $(seq 1 80); do
+    value="$(stat_value wasm.envoy.wasm.runtime.v8.active)"
+    if (( value <= maximum )); then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "active VM count stayed at ${value}, expected <= ${maximum}" >&2
+  return 1
+}
+
+request_normal() {
+  local label="$1"
+  curl --silent --show-error --max-time 5 \
+    -D "${WORKDIR}/response-${label}.headers" -o "${WORKDIR}/response-${label}.body" \
+    "http://127.0.0.1:${LISTENER_PORT}/request-recovery/${label}"
+  grep -q '^HTTP/1.1 200 ' "${WORKDIR}/response-${label}.headers"
+  grep -qi '^x-plugin-marker: ready' "${WORKDIR}/response-${label}.headers"
+  grep -qi '^x-worker-init-generation: request-recovery' \
+    "${WORKDIR}/response-${label}.headers"
+}
+
+proc_rss_kb() {
+  awk '/VmRSS:/ { print $2; found=1 } END { if (!found) print 0 }' \
+    "/proc/${ENVOY_PID}/status" 2>/dev/null || echo 0
+}
+
+proc_fd_count() {
+  find "/proc/${ENVOY_PID}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l
+}
+
+require_growth_max() {
+  local label="$1"
+  local before="$2"
+  local after="$3"
+  local maximum="$4"
+  local growth=$((after - before))
+  if (( growth > maximum )); then
+    echo "${label} growth ${growth}, expected <= ${maximum}" >&2
+    return 1
+  fi
+}
+
+prefix="wasm.envoy.wasm.runtime.v8.plugin.worker_init_repro"
+crash_stat="${prefix}.crash_total"
+recover_stat="${prefix}.recover_total"
+recover_error_stat="${prefix}.recover_error"
+retry_stat="${prefix}.worker_init_retry_total"
+uninitialized_stat="${prefix}.worker_uninitialized"
+active_stat="wasm.envoy.wasm.runtime.v8.active"
+
+request_normal baseline
+active_baseline="$(stat_value "${active_stat}")"
+if (( active_baseline < 1 )); then
+  echo "invalid active VM baseline: ${active_baseline}" >&2
+  exit 1
+fi
+crash_before="$(stat_value "${crash_stat}")"
+recover_before="$(stat_value "${recover_stat}")"
+retry_before="$(stat_value "${retry_stat}")"
+rss_before="$(proc_rss_kb)"
+fd_before="$(proc_fd_count)"
+server_memory_before="$(stat_value server.memory_allocated)"
+
+for cycle in $(seq 1 "${CYCLES}"); do
+  curl --silent --show-error --max-time 5 \
+    -H 'x-worker-init-request-trap: true' \
+    -D "${WORKDIR}/response-trap-${cycle}.headers" \
+    -o "${WORKDIR}/response-trap-${cycle}.body" \
+    "http://127.0.0.1:${LISTENER_PORT}/request-recovery/trap-${cycle}" || true
+  wait_stat_eq "${crash_stat}" "$((crash_before + cycle))"
+  sleep "${RECOVERY_WAIT_SECONDS}"
+  request_normal "recovered-${cycle}"
+  wait_stat_eq "${recover_stat}" "$((recover_before + cycle))"
+  [[ "$(stat_value "${retry_stat}")" == "${retry_before}" ]]
+  [[ "$(stat_value "${uninitialized_stat}")" == 0 ]]
+  wait_active_at_most "${active_baseline}"
+done
+
+request_normal final
+rss_after="$(proc_rss_kb)"
+fd_after="$(proc_fd_count)"
+server_memory_after="$(stat_value server.memory_allocated)"
+require_growth_max "VmRSS(kB)" "${rss_before}" "${rss_after}" "${MAX_RSS_GROWTH_KB}"
+require_growth_max "fd count" "${fd_before}" "${fd_after}" "${MAX_FD_GROWTH}"
+require_growth_max "server.memory_allocated(bytes)" "${server_memory_before}" \
+  "${server_memory_after}" "${MAX_SERVER_MEMORY_GROWTH_BYTES}"
+[[ "$(stat_value "${recover_error_stat}")" == 0 ]]
+[[ "$(stat_value "${retry_stat}")" == "${retry_before}" ]]
+wait_active_at_most "${active_baseline}"
+
+{
+  echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "envoy_bin=${ENVOY_BIN}"
+  echo "envoy_sha256=$(sha256sum "${ENVOY_BIN}" | awk '{print $1}')"
+  echo "wasm_binary=${WASM_BINARY}"
+  echo "wasm_sha256=$(sha256sum "${WASM_BINARY}" | awk '{print $1}')"
+  echo "cycles=${CYCLES}"
+  echo "active_baseline=${active_baseline}"
+  echo "active_final=$(stat_value "${active_stat}")"
+  echo "crash_total=$(stat_value "${crash_stat}")"
+  echo "recover_total=$(stat_value "${recover_stat}")"
+  echo "recover_error=$(stat_value "${recover_error_stat}")"
+  echo "worker_init_retry_total_before=${retry_before}"
+  echo "worker_init_retry_total_after=$(stat_value "${retry_stat}")"
+  echo "rss_kb=${rss_before}->${rss_after}"
+  echo "fd_count=${fd_before}->${fd_after}"
+  echo "server_memory_allocated=${server_memory_before}->${server_memory_after}"
+} | tee "${WORKDIR}/evidence.txt"
+
+cleanup_envoy
+[[ "$(grep -c 'worker-init-repro: intentional request trap' "${WORKDIR}/envoy.log")" == \
+  "${CYCLES}" ]]
+[[ "$(grep -c 'wasm vm recover from crash success' "${WORKDIR}/envoy.log")" == \
+  "${CYCLES}" ]]
+if ! grep -q '~Wasm 0 remaining active' "${WORKDIR}/console.log"; then
+  echo "Envoy shutdown did not report all Wasm VMs released" >&2
+  tail -n 80 "${WORKDIR}/console.log" >&2 || true
+  exit 1
+fi
+cleanup_upstream
+trap - EXIT
+
+echo "evidence: ${WORKDIR}/evidence.txt"
+echo "PASS"

--- a/verification/examples/wasm-worker-init-failure/run.sh
+++ b/verification/examples/wasm-worker-init-failure/run.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENVOY_BIN="${ENVOY_BIN:-}"
+WASM_BINARY="${WASM_BINARY:-}"
+WORKDIR="${WORKDIR:-/tmp/wasm-worker-init-failure}"
+LISTENER_PORT="${LISTENER_PORT:-10004}"
+ADMIN_PORT="${ADMIN_PORT:-9907}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3084}"
+BASE_ID="${BASE_ID:-121}"
+CONCURRENCY="${CONCURRENCY:-1}"
+FAIL_OPEN="${FAIL_OPEN:-true}"
+IDLE_SECONDS="${IDLE_SECONDS:-10}"
+GUARD_WAIT_SECONDS="${GUARD_WAIT_SECONDS:-1.10}"
+RECOVERY_REQUEST_LIMIT="${RECOVERY_REQUEST_LIMIT:-200}"
+PERSISTENT_ROUNDS="${PERSISTENT_ROUNDS:-7}"
+CASE="${1:-all}"
+WORKDIR_MARKER=.envoy-verification-workdir
+ENVOY_PID=""
+UPSTREAM_PID=""
+
+case "${CASE}" in
+  all|configure-reject|trap-once|trap-always|healthy) ;;
+  *) echo "usage: $0 [all|configure-reject|trap-once|trap-always|healthy]" >&2; exit 2 ;;
+esac
+if [[ -z "${ENVOY_BIN}" || "${ENVOY_BIN}" != /* || ! -x "${ENVOY_BIN}" ]]; then
+  echo "ENVOY_BIN must explicitly name an absolute executable Envoy binary" >&2
+  exit 1
+fi
+if [[ "${FAIL_OPEN}" != true && "${FAIL_OPEN}" != false ]]; then
+  echo "FAIL_OPEN must be true or false" >&2
+  exit 2
+fi
+for pair in "CONCURRENCY:${CONCURRENCY}" "IDLE_SECONDS:${IDLE_SECONDS}" \
+  "RECOVERY_REQUEST_LIMIT:${RECOVERY_REQUEST_LIMIT}" "PERSISTENT_ROUNDS:${PERSISTENT_ROUNDS}"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer" >&2
+    exit 2
+  fi
+done
+if (( PERSISTENT_ROUNDS < 6 )); then
+  echo "PERSISTENT_ROUNDS must be at least 6 to prove there is no retry cap" >&2
+  exit 2
+fi
+
+tmp_root="$(realpath -m /tmp)"
+WORKDIR="$(realpath -m "${WORKDIR}")"
+case "${WORKDIR}" in
+  "${tmp_root}"/?*) ;;
+  *) echo "WORKDIR must be a dedicated directory below ${tmp_root}" >&2; exit 1 ;;
+esac
+if [[ -d "${WORKDIR}" && ! -f "${WORKDIR}/${WORKDIR_MARKER}" ]] &&
+  find "${WORKDIR}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "refusing to clean unmarked non-empty WORKDIR: ${WORKDIR}" >&2
+  exit 1
+fi
+mkdir -p "${WORKDIR}"
+touch "${WORKDIR}/${WORKDIR_MARKER}"
+find "${WORKDIR}" -mindepth 1 -depth ! -path "${WORKDIR}/${WORKDIR_MARKER}" -delete
+
+cleanup_envoy() {
+  if [[ -n "${ENVOY_PID}" ]]; then
+    kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+    wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+    ENVOY_PID=""
+  fi
+}
+cleanup_all() {
+  cleanup_envoy
+  if [[ -n "${UPSTREAM_PID}" ]]; then
+    kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+    UPSTREAM_PID=""
+  fi
+}
+trap cleanup_all EXIT
+
+if [[ -n "${WASM_BINARY}" ]]; then
+  if [[ "${WASM_BINARY}" != /* || ! -f "${WASM_BINARY}" ]]; then
+    echo "WASM_BINARY must name an absolute existing file" >&2
+    exit 1
+  fi
+else
+  WASM_BINARY="${WORKDIR}/worker-init-repro.wasm"
+  (cd "${SCRIPT_DIR}/wasm" && GOWORK=off GOOS=wasip1 GOARCH=wasm \
+    go build -buildmode=c-shared -o "${WASM_BINARY}" .)
+fi
+
+UPSTREAM_PORT="${UPSTREAM_PORT}" python3 "${SCRIPT_DIR}/upstream_server.py" \
+  >"${WORKDIR}/upstream.log" 2>&1 &
+UPSTREAM_PID=$!
+for _ in $(seq 1 80); do
+  if curl --fail --silent --max-time 1 "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+curl --fail --silent --show-error --max-time 2 \
+  "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null
+
+prefix=wasm.envoy.wasm.runtime.v8.plugin.worker_init_repro
+retryable_stat="${prefix}.worker_init_retryable_failure_total"
+terminal_stat="${prefix}.worker_init_terminal_failure_total"
+retry_stat="${prefix}.worker_init_retry_total"
+recovered_stat="${prefix}.worker_init_recovered_total"
+skip_stat="${prefix}.worker_fail_open_skip_total"
+uninitialized_stat="${prefix}.worker_uninitialized"
+
+render_config() {
+  local mode="$1" output="$2"
+  sed -e "s#__ADMIN_PORT__#${ADMIN_PORT}#g" \
+    -e "s#__LISTENER_PORT__#${LISTENER_PORT}#g" \
+    -e "s#__UPSTREAM_PORT__#${UPSTREAM_PORT}#g" \
+    -e "s#__FAIL_OPEN__#${FAIL_OPEN}#g" \
+    -e "s#__WASM_BINARY__#${WASM_BINARY}#g" \
+    -e "s#__MODE__#${mode}#g" \
+    -e "s#__RUN_ID__#static-${mode}#g" \
+    -e "s#__WORKER_COUNT__#${CONCURRENCY}#g" \
+    -e "s#__GENERATION__#static-${mode}#g" \
+    "${SCRIPT_DIR}/config.yaml.template" >"${output}"
+}
+stat_value() {
+  local stat="$1"
+  curl --fail --silent --show-error --max-time 2 \
+    "http://127.0.0.1:${ADMIN_PORT}/stats" |
+    awk -F': ' -v stat="${stat}" '$1 == stat {print $2; found=1} END {if (!found) print 0}'
+}
+wait_stat_eq() {
+  local stat="$1" expected="$2" value=0
+  for _ in $(seq 1 120); do
+    value="$(stat_value "${stat}")"
+    [[ "${value}" == "${expected}" ]] && return 0
+    sleep 0.25
+  done
+  echo "timed out waiting for ${stat}=${expected}; last=${value}" >&2
+  return 1
+}
+request() {
+  local case_dir="$1" label="$2"
+  curl --silent --show-error --max-time 5 -H 'connection: close' \
+    -D "${case_dir}/${label}.headers" -o "${case_dir}/${label}.body" \
+    -w '%{http_code}' "http://127.0.0.1:${LISTENER_PORT}/${label}" \
+    >"${case_dir}/${label}.status" || true
+}
+require_recovered_response() {
+  local case_dir="$1" label="$2" generation="$3"
+  [[ "$(<"${case_dir}/${label}.status")" == 200 ]] &&
+    grep -qi '^x-upstream-marker: reached' "${case_dir}/${label}.headers" &&
+    grep -qi '^x-plugin-marker: ready' "${case_dir}/${label}.headers" &&
+    grep -qi "^x-worker-init-generation: ${generation}" "${case_dir}/${label}.headers"
+}
+require_failure_policy_response() {
+  local case_dir="$1" label="$2"
+  if [[ "${FAIL_OPEN}" == true ]]; then
+    [[ "$(<"${case_dir}/${label}.status")" == 200 ]] &&
+      grep -qi '^x-upstream-marker: reached' "${case_dir}/${label}.headers" &&
+      grep -qi '^x-plugin-marker: absent' "${case_dir}/${label}.headers"
+  else
+    [[ "$(<"${case_dir}/${label}.status")" == 503 ]] &&
+      ! grep -qi '^x-upstream-marker:' "${case_dir}/${label}.headers"
+  fi
+}
+require_ready_or_failure_policy_response() {
+  local case_dir="$1" label="$2" generation="$3"
+  if require_recovered_response "${case_dir}" "${label}" "${generation}"; then
+    return 0
+  fi
+  require_failure_policy_response "${case_dir}" "${label}"
+}
+require_tls_roles() {
+  local case_dir="$1" generation="$2"
+  local total=0 main_records=0 worker_tids=0 expected_total=$((CONCURRENCY + 2))
+  for _ in $(seq 1 120); do
+    read -r total main_records worker_tids < <(
+      awk -v generation="generation=${generation} " -v main_tid="${ENVOY_PID}" '
+        index($0, "worker-init-repro: plugin start") && index($0, generation) {
+          total++
+          split($0, fields, /\]\[/)
+          tid = fields[2]
+          if (tid == main_tid) {
+            main_records++
+          } else {
+            worker[tid] = 1
+          }
+        }
+        END {
+          for (tid in worker) worker_tids++
+          print total + 0, main_records + 0, worker_tids + 0
+        }
+      ' "${case_dir}/envoy.log")
+    if [[ "${total}" == "${expected_total}" && "${main_records}" == 2 &&
+      "${worker_tids}" == "${CONCURRENCY}" ]]; then
+      printf 'generation=%s\nmain_thread_tid=%s\nplugin_start_records=%s\nmain_thread_records=%s\nworker_tids=%s\n' \
+        "${generation}" "${ENVOY_PID}" "${total}" "${main_records}" "${worker_tids}" \
+        >"${case_dir}/tls-role-evidence.txt"
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "TLS role mismatch for ${generation}: total=${total}, main=${main_records}, " \
+    "worker_tids=${worker_tids}" >&2
+  return 1
+}
+
+run_case() {
+  local mode="$1"
+  local case_dir="${WORKDIR}/${mode}"
+  local config="${case_dir}/envoy.yaml"
+  mkdir -p "${case_dir}"
+  render_config "${mode}" "${config}"
+  "${ENVOY_BIN}" --mode validate -c "${config}" --log-level error \
+    >"${case_dir}/validate.log" 2>&1
+  "${ENVOY_BIN}" -c "${config}" --concurrency "${CONCURRENCY}" --base-id "${BASE_ID}" \
+    --file-flush-interval-msec 100 \
+    --log-level warn --component-log-level wasm:debug --log-path "${case_dir}/envoy.log" \
+    >"${case_dir}/console.log" 2>&1 &
+  ENVOY_PID=$!
+  local ready=false
+  for _ in $(seq 1 120); do
+    if kill -0 "${ENVOY_PID}" >/dev/null 2>&1 &&
+      curl --fail --silent --max-time 1 "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    sleep 0.25
+  done
+  [[ "${ready}" == true ]] || { echo "Envoy did not become ready for ${mode}" >&2; return 1; }
+  require_tls_roles "${case_dir}" "static-${mode}"
+
+  case "${mode}" in
+    healthy)
+      request "${case_dir}" healthy
+      require_recovered_response "${case_dir}" healthy static-healthy
+      [[ "$(stat_value "${retryable_stat}")" == 0 ]]
+      [[ "$(stat_value "${terminal_stat}")" == 0 ]]
+      [[ "$(stat_value "${retry_stat}")" == 0 ]]
+      [[ "$(stat_value "${recovered_stat}")" == 0 ]]
+      [[ "$(stat_value "${uninitialized_stat}")" == 0 ]]
+      ;;
+    configure-reject)
+      wait_stat_eq "${terminal_stat}" "${CONCURRENCY}"
+      wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+      local terminal_retry_before
+      terminal_retry_before="$(stat_value "${retry_stat}")"
+      sleep "${IDLE_SECONDS}"
+      for i in $(seq 1 "$((2 * CONCURRENCY + 2))"); do
+        request "${case_dir}" "terminal-${i}"
+        require_failure_policy_response "${case_dir}" "terminal-${i}"
+      done
+      [[ "$(stat_value "${retry_stat}")" == "${terminal_retry_before}" ]]
+      ;;
+    trap-once)
+      wait_stat_eq "${retryable_stat}" "${CONCURRENCY}"
+      wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+      local idle_retry recovered before after label
+      idle_retry="$(stat_value "${retry_stat}")"
+      sleep "${IDLE_SECONDS}"
+      [[ "$(stat_value "${retry_stat}")" == "${idle_retry}" ]]
+      recovered="$(stat_value "${recovered_stat}")"
+      for i in $(seq 1 "${RECOVERY_REQUEST_LIMIT}"); do
+        label="recover-${i}"
+        before="${recovered}"
+        request "${case_dir}" "${label}"
+        after="$(stat_value "${recovered_stat}")"
+        if (( after > before )); then
+          require_recovered_response "${case_dir}" "${label}" static-trap-once
+        else
+          require_ready_or_failure_policy_response "${case_dir}" "${label}" static-trap-once
+        fi
+        recovered="${after}"
+        (( recovered == CONCURRENCY )) && break
+      done
+      [[ "${recovered}" == "${CONCURRENCY}" ]]
+      wait_stat_eq "${uninitialized_stat}" 0
+      [[ "$(stat_value "${retry_stat}")" == "${CONCURRENCY}" ]]
+      ;;
+    trap-always)
+      wait_stat_eq "${retryable_stat}" "${CONCURRENCY}"
+      wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+      local persistent_before immediate_after persistent_after round
+      persistent_before="$(stat_value "${retry_stat}")"
+      sleep "${IDLE_SECONDS}"
+      [[ "$(stat_value "${retry_stat}")" == "${persistent_before}" ]]
+      for i in $(seq 1 "${RECOVERY_REQUEST_LIMIT}"); do
+        request "${case_dir}" "persistent-first-${i}"
+        require_failure_policy_response "${case_dir}" "persistent-first-${i}"
+        immediate_after="$(stat_value "${retry_stat}")"
+        (( immediate_after == persistent_before + CONCURRENCY )) && break
+      done
+      [[ "${immediate_after}" == "$((persistent_before + CONCURRENCY))" ]]
+      for i in $(seq 1 "$((2 * CONCURRENCY))"); do
+        request "${case_dir}" "persistent-guard-${i}"
+        require_failure_policy_response "${case_dir}" "persistent-guard-${i}"
+      done
+      [[ "$(stat_value "${retry_stat}")" == "${immediate_after}" ]]
+      for round in $(seq 2 "${PERSISTENT_ROUNDS}"); do
+        sleep "${GUARD_WAIT_SECONDS}"
+        for i in $(seq 1 "$((2 * CONCURRENCY))"); do
+          request "${case_dir}" "persistent-${round}-${i}"
+          require_failure_policy_response "${case_dir}" "persistent-${round}-${i}"
+        done
+      done
+      persistent_after="$(stat_value "${retry_stat}")"
+      (( persistent_after - persistent_before >= PERSISTENT_ROUNDS ))
+      [[ "$(stat_value "${recovered_stat}")" == 0 ]]
+      [[ "$(stat_value "${uninitialized_stat}")" == "${CONCURRENCY}" ]]
+      ;;
+  esac
+
+  {
+    echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "mode=${mode}"
+    echo "fail_open=${FAIL_OPEN}"
+    echo "concurrency=${CONCURRENCY}"
+    echo "idle_seconds=${IDLE_SECONDS}"
+    echo "guard_wait_seconds=${GUARD_WAIT_SECONDS}"
+    echo "envoy_bin=${ENVOY_BIN}"
+    echo "envoy_sha256=$(sha256sum "${ENVOY_BIN}" | awk '{print $1}')"
+    echo "wasm_binary=${WASM_BINARY}"
+    echo "wasm_sha256=$(sha256sum "${WASM_BINARY}" | awk '{print $1}')"
+    echo "config_sha256=$(sha256sum "${config}" | awk '{print $1}')"
+    echo "worker_init_retryable_failure_total=$(stat_value "${retryable_stat}")"
+    echo "worker_init_terminal_failure_total=$(stat_value "${terminal_stat}")"
+    echo "worker_init_retry_total=$(stat_value "${retry_stat}")"
+    echo "worker_init_recovered_total=$(stat_value "${recovered_stat}")"
+    echo "worker_fail_open_skip_total=$(stat_value "${skip_stat}")"
+    echo "worker_uninitialized=$(stat_value "${uninitialized_stat}")"
+  } | tee "${case_dir}/evidence.txt"
+  cleanup_envoy
+  grep 'worker-init-repro: plugin start' "${case_dir}/envoy.log" >"${case_dir}/attempts.log"
+  grep -E 'wasm worker initialization (failed|retry failed|retry became terminal|recovered)|cooldown' \
+    "${case_dir}/envoy.log" >"${case_dir}/host-worker-init.log" || true
+  grep -q '~Wasm 0 remaining active' "${case_dir}/console.log"
+}
+
+if [[ "${CASE}" == all ]]; then
+  for mode in configure-reject trap-once trap-always healthy; do run_case "${mode}"; done
+else
+  run_case "${CASE}"
+fi
+cleanup_all
+trap - EXIT
+echo "evidence: ${WORKDIR}"
+echo PASS

--- a/verification/examples/wasm-worker-init-failure/soak/analyze.py
+++ b/verification/examples/wasm-worker-init-failure/soak/analyze.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Summarize fixed-window resource medians and enforce predeclared soak bounds."""
+
+import argparse
+import csv
+import statistics
+import sys
+from pathlib import Path
+
+
+METRICS = (
+    "fd_count",
+    "thread_count",
+    "server_memory_allocated",
+    "server_memory_heap_size",
+    "rss_kb",
+    "rss_anon_kb",
+    "pss_kb",
+    "private_dirty_kb",
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--window-seconds", required=True, type=int)
+    parser.add_argument("--minimum-events", required=True, type=int)
+    parser.add_argument("--duration-seconds", required=True, type=int)
+    parser.add_argument("--sample-interval-seconds", required=True, type=int)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.window_seconds <= 0 or args.duration_seconds <= 0:
+        raise SystemExit("window and duration must be positive")
+    if args.sample_interval_seconds <= 0:
+        raise SystemExit("sample interval must be positive")
+    if args.duration_seconds % args.window_seconds != 0:
+        raise SystemExit("duration must be an integer multiple of the fixed window")
+    if args.sample_interval_seconds >= args.window_seconds:
+        raise SystemExit("sample interval must be smaller than the fixed window")
+    with args.input.open(newline="", encoding="utf-8") as source:
+        rows = list(csv.DictReader(source))
+    if not rows:
+        raise SystemExit("sample CSV is empty")
+    required = {"elapsed_seconds", "events", *METRICS}
+    missing = required.difference(rows[0])
+    if missing:
+        raise SystemExit(f"sample CSV lacks columns: {sorted(missing)}")
+
+    all_values = []
+    for row in rows:
+        values = {name: int(row[name]) for name in required}
+        all_values.append(values)
+
+    previous_elapsed = None
+    previous_events = None
+    for values in all_values:
+        elapsed = values["elapsed_seconds"]
+        events = values["events"]
+        if elapsed < 0:
+            raise SystemExit("elapsed seconds must be non-negative")
+        if previous_elapsed is not None and elapsed <= previous_elapsed:
+            raise SystemExit("elapsed seconds are not strictly increasing")
+        if previous_events is not None and events < previous_events:
+            raise SystemExit("event count decreased between samples")
+        previous_elapsed = elapsed
+        previous_events = events
+
+    parsed = []
+    for values in all_values:
+        if values["elapsed_seconds"] < args.duration_seconds:
+            parsed.append(values)
+    if not parsed:
+        raise SystemExit("sample CSV has no rows inside the declared measured duration")
+    terminal = all_values[-1]
+    if terminal["elapsed_seconds"] != args.duration_seconds:
+        raise SystemExit("sample CSV must end with exactly one duration-boundary sample")
+    if terminal["events"] < args.minimum_events:
+        raise SystemExit(
+            f"observed {terminal['events']} events, expected at least {args.minimum_events}"
+        )
+
+    windows = {}
+    for row in parsed:
+        index = row["elapsed_seconds"] // args.window_seconds
+        windows.setdefault(index, []).append(row)
+    expected_windows = args.duration_seconds // args.window_seconds
+    expected_samples = (
+        args.window_seconds + args.sample_interval_seconds - 1
+    ) // args.sample_interval_seconds
+    minimum_samples = max(1, expected_samples - 1)
+    windows = {index: group for index, group in windows.items() if index < expected_windows}
+    for index in range(expected_windows):
+        group = windows.get(index, [])
+        if not group:
+            raise SystemExit(f"fixed window {index} has no samples")
+        if len(group) < minimum_samples:
+            raise SystemExit(
+                f"fixed window {index} has {len(group)} samples, "
+                f"expected at least {minimum_samples}"
+            )
+        elapsed = [row["elapsed_seconds"] for row in group]
+        if min(elapsed) > index * args.window_seconds + args.sample_interval_seconds or max(
+            elapsed
+        ) < (index + 1) * args.window_seconds - args.sample_interval_seconds:
+            raise SystemExit(f"fixed window {index} is incomplete")
+    if len(windows) < 2:
+        raise SystemExit("need at least two fixed windows")
+
+    summaries = []
+    for index in sorted(windows):
+        group = windows[index]
+        summary = {
+            "window": index,
+            "start_seconds": index * args.window_seconds,
+            "end_seconds": (index + 1) * args.window_seconds,
+            "events": max(row["events"] for row in group),
+        }
+        for metric in METRICS:
+            values = [row[metric] for row in group]
+            summary[f"{metric}_median"] = int(statistics.median(values))
+            summary[f"{metric}_max"] = max(values)
+        summaries.append(summary)
+
+    with args.output.open("w", newline="", encoding="utf-8") as target:
+        writer = csv.DictWriter(target, fieldnames=summaries[0].keys())
+        writer.writeheader()
+        writer.writerows(summaries)
+
+    first, last = summaries[0], summaries[-1]
+    event_delta = last["events"] - first["events"]
+    if event_delta <= 0:
+        raise SystemExit("event count did not grow across measured windows")
+    absolute_limits = {
+        "fd_count": 8,
+        "thread_count": 0,
+        "server_memory_allocated": 32 * 1024 * 1024,
+        "server_memory_heap_size": 32 * 1024 * 1024,
+        "rss_kb": 64 * 1024,
+        "rss_anon_kb": 64 * 1024,
+        "pss_kb": 64 * 1024,
+        "private_dirty_kb": 64 * 1024,
+    }
+    trend_limits = {
+        "server_memory_allocated": 1 * 1024 * 1024,
+        "server_memory_heap_size": 1 * 1024 * 1024,
+        "rss_kb": 4 * 1024,
+        "rss_anon_kb": 4 * 1024,
+        "pss_kb": 4 * 1024,
+        "private_dirty_kb": 4 * 1024,
+    }
+    failures = []
+    # Use stable edge sequences rather than individual samples/windows. Trend is a least-squares
+    # fit over every fixed-window median, normalized by that run's observed event count.
+    edge_count = max(1, min(2, len(summaries) // 2))
+    for metric, limit in absolute_limits.items():
+        if any(summary[f"{metric}_median"] < 0 for summary in summaries):
+            continue
+        first_edge = statistics.median(
+            summary[f"{metric}_median"] for summary in summaries[:edge_count]
+        )
+        last_edge = statistics.median(
+            summary[f"{metric}_median"] for summary in summaries[-edge_count:]
+        )
+        growth = last_edge - first_edge
+        if growth > limit:
+            failures.append(f"{metric} stable-window median growth {growth} > {limit}")
+        # A two-window smoke run has only one edge-to-edge segment, so normal allocator warm-up is
+        # amplified by per-100-event normalization. Keep its absolute bounds, but reserve the
+        # least-squares trend gate for the three-or-more windows used by formal runs.
+        if metric in trend_limits and len(summaries) >= 3:
+            xs = [summary["events"] for summary in summaries]
+            ys = [summary[f"{metric}_median"] for summary in summaries]
+            x_mean = statistics.mean(xs)
+            y_mean = statistics.mean(ys)
+            denominator = sum((value - x_mean) ** 2 for value in xs)
+            slope = 0 if denominator == 0 else sum(
+                (x - x_mean) * (y - y_mean) for x, y in zip(xs, ys)
+            ) / denominator
+            per_100 = max(0, slope) * 100
+            if per_100 > trend_limits[metric]:
+                failures.append(
+                    f"{metric} window-regression trend {per_100:.1f}/100 events "
+                    f"> {trend_limits[metric]}"
+                )
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    trend = (
+        "window_regression_per_100_events"
+        if len(summaries) >= 3
+        else "not_enforced_under_3_windows"
+    )
+    print(
+        f"PASS samples={len(parsed)} windows={len(summaries)} events={terminal['events']} "
+        f"last_window_events={parsed[-1]['events']} "
+        f"stable_edge_windows={edge_count} trend={trend}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/examples/wasm-worker-init-failure/soak/compare.py
+++ b/verification/examples/wasm-worker-init-failure/soak/compare.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Enforce recovery-run growth relative to its paired healthy control."""
+
+import argparse
+import csv
+import statistics
+import sys
+from pathlib import Path
+
+
+METRICS = (
+    "fd_count",
+    "thread_count",
+    "server_memory_allocated",
+    "server_memory_heap_size",
+    "rss_kb",
+    "rss_anon_kb",
+    "pss_kb",
+    "private_dirty_kb",
+)
+
+
+def read(path):
+    with path.open(newline="", encoding="utf-8") as source:
+        return [{key: int(value) for key, value in row.items()} for row in csv.DictReader(source)]
+
+
+def growth_and_slope(rows, metric):
+    edge_count = max(1, min(2, len(rows) // 2))
+    first_edge = statistics.median(row[f"{metric}_median"] for row in rows[:edge_count])
+    last_edge = statistics.median(row[f"{metric}_median"] for row in rows[-edge_count:])
+    xs = [row["events"] for row in rows]
+    ys = [row[f"{metric}_median"] for row in rows]
+    x_mean = statistics.mean(xs)
+    y_mean = statistics.mean(ys)
+    denominator = sum((value - x_mean) ** 2 for value in xs)
+    slope = 0 if denominator == 0 else sum(
+        (x - x_mean) * (y - y_mean) for x, y in zip(xs, ys)
+    ) / denominator
+    return last_edge - first_edge, slope * 100
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--actual", required=True, type=Path)
+    parser.add_argument("--control", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    actual = read(args.actual)
+    control = read(args.control)
+    if len(actual) < 2 or len(control) < 2:
+        raise SystemExit("paired comparison requires at least two windows in each run")
+    trend_enforced = len(actual) >= 3 and len(control) >= 3
+
+    growth_limits = {
+        "fd_count": 4,
+        "thread_count": 0,
+        "server_memory_allocated": 16 * 1024 * 1024,
+        "server_memory_heap_size": 16 * 1024 * 1024,
+        "rss_kb": 32 * 1024,
+        "rss_anon_kb": 32 * 1024,
+        "pss_kb": 32 * 1024,
+        "private_dirty_kb": 32 * 1024,
+    }
+    trend_limits = {
+        "server_memory_allocated": 512 * 1024,
+        "server_memory_heap_size": 512 * 1024,
+        "rss_kb": 2 * 1024,
+        "rss_anon_kb": 2 * 1024,
+        "pss_kb": 2 * 1024,
+        "private_dirty_kb": 2 * 1024,
+    }
+    failures = []
+    records = []
+    for metric in METRICS:
+        if any(row[f"{metric}_median"] < 0 for row in actual + control):
+            continue
+        actual_growth, actual_slope = growth_and_slope(actual, metric)
+        control_growth, control_slope = growth_and_slope(control, metric)
+        extra_growth = actual_growth - control_growth
+        extra_slope = actual_slope - control_slope
+        records.append(
+            {
+                "metric": metric,
+                "actual_stable_growth": f"{actual_growth:.1f}",
+                "control_stable_growth": f"{control_growth:.1f}",
+                "extra_stable_growth": f"{extra_growth:.1f}",
+                "actual_trend_per_100_events": f"{actual_slope:.1f}",
+                "control_trend_per_100_events": f"{control_slope:.1f}",
+                "extra_trend_per_100_events": f"{extra_slope:.1f}",
+            }
+        )
+        if extra_growth > growth_limits[metric]:
+            failures.append(
+                f"{metric} recovery-minus-control stable growth {extra_growth:.1f} "
+                f"> {growth_limits[metric]}"
+            )
+        if trend_enforced and metric in trend_limits and extra_slope > trend_limits[metric]:
+            failures.append(
+                f"{metric} recovery-minus-control trend {extra_slope:.1f}/100 events "
+                f"> {trend_limits[metric]}"
+            )
+    with args.output.open("w", newline="", encoding="utf-8") as target:
+        writer = csv.DictWriter(target, fieldnames=records[0].keys())
+        writer.writeheader()
+        writer.writerows(records)
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    trend_mode = "enforced" if trend_enforced else "recorded_only"
+    print(f"PASS paired stable-window growth; per-100-event trends={trend_mode}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/examples/wasm-worker-init-failure/soak/run.sh
+++ b/verification/examples/wasm-worker-init-failure/soak/run.sh
@@ -1,0 +1,1053 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ECDS_DIR="${PARENT_DIR}/ecds-replacement"
+ENVOY_BIN="${ENVOY_BIN:-}"
+WASM_BINARY="${WASM_BINARY:-}"
+WORKDIR="${WORKDIR:-/tmp/wasm-worker-init-soak}"
+PROFILE="${PROFILE:-smoke}"
+SCENARIO="${SCENARIO:-all}"
+CONCURRENCY="${CONCURRENCY:-1}"
+LISTENER_PORT="${LISTENER_PORT:-10007}"
+ADMIN_PORT="${ADMIN_PORT:-9910}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3087}"
+BASE_ID="${BASE_ID:-127}"
+EVENT_INTERVAL_MS="${EVENT_INTERVAL_MS:-1100}"
+READY_GUARD_WAIT_MS="${READY_GUARD_WAIT_MS:-1050}"
+REQUESTS_PER_EVENT="${REQUESTS_PER_EVENT:-}"
+READY_SCAN_LIMIT="${READY_SCAN_LIMIT:-200}"
+MAX_REPLAY_LAG_MS="${MAX_REPLAY_LAG_MS:-5000}"
+READY_SCHEDULE_VALIDATE_ONLY_DIR="${READY_SCHEDULE_VALIDATE_ONLY_DIR:-}"
+INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR="${INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR:-}"
+SAMPLE_INTERVAL_SECONDS="${SAMPLE_INTERVAL_SECONDS:-10}"
+WINDOW_SECONDS="${WINDOW_SECONDS:-}"
+WARMUP_SECONDS="${WARMUP_SECONDS:-}"
+DURATION_SECONDS="${DURATION_SECONDS:-}"
+REPETITIONS="${REPETITIONS:-}"
+MIN_INITIALIZATION_RECOVERIES="${MIN_INITIALIZATION_RECOVERIES:-}"
+MIN_READY_RECOVERIES="${MIN_READY_RECOVERIES:-}"
+MIN_PERSISTENT_ATTEMPTS="${MIN_PERSISTENT_ATTEMPTS:-}"
+WORKDIR_MARKER=.envoy-verification-workdir
+ENVOY_PID=""
+UPSTREAM_PID=""
+LAST_LATENCY_MS=0
+EVENT_SEQUENCE=0
+MEASURED_EVENTS=0
+EVENT_START_OFFSET_MS=0
+EXPECTED_ACTIVE_STEADY=0
+EXPECTED_UNINITIALIZED_STEADY=0
+READY_REPLAY_SCAN_COUNT=0
+READY_SCHEDULE_ROWS=()
+READY_ROUND_SCAN_COUNTS=()
+declare -A READY_REQUEST_OFFSETS
+INITIALIZATION_REPLAY_SCAN_COUNT=0
+INITIALIZATION_SCHEDULE_ROWS=()
+INITIALIZATION_ROUND_SCAN_COUNTS=()
+declare -A INITIALIZATION_REQUEST_OFFSETS
+
+if [[ -z "${ENVOY_BIN}" || "${ENVOY_BIN}" != /* || ! -x "${ENVOY_BIN}" ]]; then
+  echo "ENVOY_BIN must explicitly name an absolute executable Envoy binary" >&2
+  exit 1
+fi
+case "${PROFILE}" in
+  smoke)
+    WARMUP_SECONDS="${WARMUP_SECONDS:-10}"
+    DURATION_SECONDS="${DURATION_SECONDS:-60}"
+    WINDOW_SECONDS="${WINDOW_SECONDS:-30}"
+    REPETITIONS="${REPETITIONS:-1}"
+    MIN_INITIALIZATION_RECOVERIES="${MIN_INITIALIZATION_RECOVERIES:-6}"
+    MIN_READY_RECOVERIES="${MIN_READY_RECOVERIES:-6}"
+    MIN_PERSISTENT_ATTEMPTS="${MIN_PERSISTENT_ATTEMPTS:-6}"
+    ;;
+  formal)
+    WARMUP_SECONDS="${WARMUP_SECONDS:-300}"
+    DURATION_SECONDS="${DURATION_SECONDS:-900}"
+    WINDOW_SECONDS="${WINDOW_SECONDS:-300}"
+    REPETITIONS="${REPETITIONS:-1}"
+    MIN_INITIALIZATION_RECOVERIES="${MIN_INITIALIZATION_RECOVERIES:-1000}"
+    MIN_READY_RECOVERIES="${MIN_READY_RECOVERIES:-600}"
+    MIN_PERSISTENT_ATTEMPTS="${MIN_PERSISTENT_ATTEMPTS:-600}"
+    ;;
+  *) echo "PROFILE must be smoke or formal" >&2; exit 2 ;;
+esac
+if [[ "${PROFILE}" == formal && "${CONCURRENCY}" != 4 ]]; then
+  echo "formal profile requires CONCURRENCY=4" >&2
+  exit 2
+fi
+if [[ -z "${REQUESTS_PER_EVENT}" ]]; then
+  REQUESTS_PER_EVENT=$((2 * CONCURRENCY))
+fi
+case "${SCENARIO}" in all|initialization|ready|persistent) ;; *) echo "invalid SCENARIO" >&2; exit 2;; esac
+for pair in "CONCURRENCY:${CONCURRENCY}" "EVENT_INTERVAL_MS:${EVENT_INTERVAL_MS}" \
+  "READY_GUARD_WAIT_MS:${READY_GUARD_WAIT_MS}" \
+  "SAMPLE_INTERVAL_SECONDS:${SAMPLE_INTERVAL_SECONDS}" "WINDOW_SECONDS:${WINDOW_SECONDS}" \
+  "WARMUP_SECONDS:${WARMUP_SECONDS}" "DURATION_SECONDS:${DURATION_SECONDS}" \
+  "REPETITIONS:${REPETITIONS}"; do
+  name="${pair%%:*}"; value="${pair#*:}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || { echo "${name} must be positive" >&2; exit 2; }
+done
+(( READY_GUARD_WAIT_MS >= 1000 )) || {
+  echo "READY_GUARD_WAIT_MS must preserve the 1-second recovery guard" >&2
+  exit 2
+}
+for pair in "READY_SCAN_LIMIT:${READY_SCAN_LIMIT}" "MAX_REPLAY_LAG_MS:${MAX_REPLAY_LAG_MS}"; do
+  name="${pair%%:*}"; value="${pair#*:}"
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || { echo "${name} must be positive" >&2; exit 2; }
+done
+[[ "${REQUESTS_PER_EVENT}" =~ ^[1-9][0-9]*$ ]] || {
+  echo "REQUESTS_PER_EVENT must be positive" >&2; exit 2;
+}
+(( REQUESTS_PER_EVENT >= 2 * CONCURRENCY )) || {
+  echo "REQUESTS_PER_EVENT must be at least 2*CONCURRENCY" >&2; exit 2;
+}
+(( DURATION_SECONDS >= 2 * WINDOW_SECONDS )) || {
+  echo "DURATION_SECONDS must cover at least two analysis windows" >&2; exit 2;
+}
+(( DURATION_SECONDS % WINDOW_SECONDS == 0 )) || {
+  echo "DURATION_SECONDS must be an integer multiple of WINDOW_SECONDS" >&2; exit 2;
+}
+(( SAMPLE_INTERVAL_SECONDS < WINDOW_SECONDS )) || {
+  echo "SAMPLE_INTERVAL_SECONDS must be smaller than WINDOW_SECONDS" >&2; exit 2;
+}
+
+tmp_root="$(realpath -m /tmp)"
+WORKDIR="$(realpath -m "${WORKDIR}")"
+case "${WORKDIR}" in "${tmp_root}"/?*) ;; *) echo "WORKDIR must be below /tmp" >&2; exit 1;; esac
+if [[ -d "${WORKDIR}" && ! -f "${WORKDIR}/${WORKDIR_MARKER}" ]] &&
+  find "${WORKDIR}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+  echo "refusing to clean unmarked non-empty WORKDIR: ${WORKDIR}" >&2
+  exit 1
+fi
+mkdir -p "${WORKDIR}"
+touch "${WORKDIR}/${WORKDIR_MARKER}"
+find "${WORKDIR}" -mindepth 1 -depth ! -path "${WORKDIR}/${WORKDIR_MARKER}" -delete
+
+if [[ -n "${WASM_BINARY}" ]]; then
+  [[ "${WASM_BINARY}" == /* && -f "${WASM_BINARY}" ]] || { echo "invalid WASM_BINARY" >&2; exit 1; }
+else
+  WASM_BINARY="${WORKDIR}/worker-init-repro.wasm"
+  (cd "${PARENT_DIR}/wasm" && GOWORK=off GOOS=wasip1 GOARCH=wasm \
+    go build -buildmode=c-shared -o "${WASM_BINARY}" .)
+fi
+
+cat_manifest="${WORKDIR}/campaign.txt"
+{
+  echo "declared_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "profile=${PROFILE}"
+  echo "scenario=${SCENARIO}"
+  echo "envoy_bin=${ENVOY_BIN}"
+  echo "envoy_sha256=$(sha256sum "${ENVOY_BIN}" | awk '{print $1}')"
+  echo "wasm_binary=${WASM_BINARY}"
+  echo "wasm_sha256=$(sha256sum "${WASM_BINARY}" | awk '{print $1}')"
+  echo "concurrency=${CONCURRENCY}"
+  echo "warmup_seconds=${WARMUP_SECONDS}"
+  echo "duration_seconds=${DURATION_SECONDS}"
+  echo "sample_interval_seconds=${SAMPLE_INTERVAL_SECONDS}"
+  echo "window_seconds=${WINDOW_SECONDS}"
+  echo "event_interval_ms=${EVENT_INTERVAL_MS}"
+  echo "ready_guard_wait_ms=${READY_GUARD_WAIT_MS}"
+  echo "requests_per_event=${REQUESTS_PER_EVENT}"
+  echo "ready_scan_limit=${READY_SCAN_LIMIT}"
+  echo "max_replay_lag_ms=${MAX_REPLAY_LAG_MS}"
+  echo "repetitions=${REPETITIONS}"
+  echo "minimum_initialization_recoveries=${MIN_INITIALIZATION_RECOVERIES}"
+  echo "minimum_ready_recoveries=${MIN_READY_RECOVERIES}"
+  echo "minimum_persistent_attempts=${MIN_PERSISTENT_ATTEMPTS}"
+  echo "absolute_fd_growth=8"
+  echo "absolute_thread_growth=0"
+  echo "absolute_allocated_growth_bytes=33554432"
+  echo "absolute_heap_growth_bytes=33554432"
+  echo "absolute_rss_pss_dirty_growth_kb=65536"
+  echo "trend_allocated_growth_bytes_per_100_events=1048576"
+  echo "trend_heap_growth_bytes_per_100_events=1048576"
+  echo "trend_rss_pss_dirty_growth_kb_per_100_events=4096"
+  echo "paired_extra_fd_growth=4"
+  echo "paired_extra_thread_growth=0"
+  echo "paired_extra_allocated_growth_bytes=16777216"
+  echo "paired_extra_heap_growth_bytes=16777216"
+  echo "paired_extra_rss_pss_dirty_growth_kb=32768"
+  echo "paired_extra_allocated_growth_bytes_per_100_events=524288"
+  echo "paired_extra_heap_growth_bytes_per_100_events=524288"
+  echo "paired_extra_rss_pss_dirty_growth_kb_per_100_events=2048"
+  echo "growth_basis=median_of_up_to_two_edge_windows"
+  echo "growth_edge_count=max(1,min(2,floor(window_count/2)));formal_three_windows=first_vs_last"
+  echo "trend_basis=least_squares_over_all_fixed_window_medians_per_100_events"
+} >"${cat_manifest}"
+
+cleanup_case() {
+  if [[ -n "${ENVOY_PID}" ]]; then kill "${ENVOY_PID}" >/dev/null 2>&1 || true; wait "${ENVOY_PID}" >/dev/null 2>&1 || true; ENVOY_PID=""; fi
+  if [[ -n "${UPSTREAM_PID}" ]]; then kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true; wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true; UPSTREAM_PID=""; fi
+}
+trap cleanup_case EXIT
+
+prefix=wasm.envoy.wasm.runtime.v8.plugin.worker_init_repro
+retryable_stat="${prefix}.worker_init_retryable_failure_total"
+retry_stat="${prefix}.worker_init_retry_total"
+recovered_stat="${prefix}.worker_init_recovered_total"
+crash_stat="${prefix}.crash_total"
+recover_stat="${prefix}.recover_total"
+recover_error_stat="${prefix}.recover_error"
+uninitialized_stat="${prefix}.worker_uninitialized"
+active_stat=wasm.envoy.wasm.runtime.v8.active
+
+stat_value() {
+  local stat="$1" missing="${2:-0}" filter="${1//./\\.}"
+  curl --fail --silent --show-error --max-time 2 --get \
+    --data-urlencode "filter=^${filter}$" "http://127.0.0.1:${ADMIN_PORT}/stats" |
+    awk -F': ' -v stat="${stat}" -v missing="${missing}" \
+      '$1 == stat {print $2; found=1} END {if (!found) print missing}'
+}
+wait_until_ms() {
+  local target_ms="$1" now_ms remaining_ms wait_seconds
+  now_ms="$(date +%s%3N)"
+  if (( now_ms < target_ms )); then
+    remaining_ms=$((target_ms - now_ms))
+    printf -v wait_seconds '%d.%03d' "$((remaining_ms / 1000))" "$((remaining_ms % 1000))"
+    sleep "${wait_seconds}"
+  fi
+}
+wait_stat_at_least() {
+  local stat="$1" expected="$2" value=0
+  for _ in $(seq 1 200); do
+    value="$(stat_value "${stat}")"
+    (( value >= expected )) && return 0
+    sleep 0.05
+  done
+  echo "timed out waiting for ${stat} >= ${expected}; last=${value}" >&2
+  return 1
+}
+wait_stat_eq() {
+  local stat="$1" expected="$2" value=0
+  for _ in $(seq 1 200); do
+    value="$(stat_value "${stat}")"
+    [[ "${value}" == "${expected}" ]] && return 0
+    sleep 0.05
+  done
+  echo "timed out waiting for ${stat}=${expected}; last=${value}" >&2
+  return 1
+}
+wait_active_at_most() {
+  local expected="$1" value=0
+  for _ in $(seq 1 200); do
+    value="$(stat_value "${active_stat}")"
+    (( value <= expected )) && return 0
+    sleep 0.05
+  done
+  echo "active VM count ${value} exceeds baseline ${expected}" >&2
+  return 1
+}
+request() {
+  local run_dir="$1" label="$2" trap_header="${3:-false}"
+  local start_ms end_ms
+  start_ms="$(date +%s%3N)"
+  if [[ "${trap_header}" == true ]]; then
+    curl --silent --show-error --max-time 5 -H 'connection: close' \
+      -H 'x-worker-init-request-trap: true' -D "${run_dir}/last.headers" \
+      -o "${run_dir}/last.body" "http://127.0.0.1:${LISTENER_PORT}/${label}" || true
+  else
+    curl --silent --show-error --max-time 5 -H 'connection: close' \
+      -D "${run_dir}/last.headers" -o "${run_dir}/last.body" \
+      "http://127.0.0.1:${LISTENER_PORT}/${label}" || true
+  fi
+  end_ms="$(date +%s%3N)"
+  LAST_LATENCY_MS=$((end_ms - start_ms))
+}
+install_generation() {
+  local run_dir="$1" mode="$2" generation="$3" run_id="$4"
+  local next="${run_dir}/ecds.yaml.next"
+  sed -e 's#__FAIL_OPEN__#true#g' -e "s#__WASM_BINARY__#${WASM_BINARY}#g" \
+    -e "s#__MODE__#${mode}#g" -e "s#__RUN_ID__#${run_id}#g" \
+    -e "s#__WORKER_COUNT__#${CONCURRENCY}#g" -e "s#__GENERATION__#${generation}#g" \
+    "${ECDS_DIR}/ecds.yaml.template" >"${next}"
+  mv "${next}" "${run_dir}/ecds.yaml"
+}
+wait_log_generation() {
+  local run_dir="$1" generation="$2"
+  for _ in $(seq 1 200); do
+    grep -Fq "generation=${generation} " "${run_dir}/envoy.log" 2>/dev/null && return 0
+    sleep 0.05
+  done
+  echo "timed out waiting for ECDS generation ${generation}" >&2
+  return 1
+}
+require_tls_roles() {
+  local run_dir="$1" generation="$2"
+  local total=0 main_records=0 worker_tids=0 expected_total=$((CONCURRENCY + 2))
+  for _ in $(seq 1 120); do
+    read -r total main_records worker_tids < <(
+      awk -v generation="generation=${generation} " -v main_tid="${ENVOY_PID}" '
+        index($0, "worker-init-repro: plugin start") && index($0, generation) {
+          total++
+          split($0, fields, /\]\[/)
+          tid = fields[2]
+          if (tid == main_tid) {
+            main_records++
+          } else {
+            worker[tid] = 1
+          }
+        }
+        END {
+          for (tid in worker) worker_tids++
+          print total + 0, main_records + 0, worker_tids + 0
+        }
+      ' "${run_dir}/envoy.log")
+    if [[ "${total}" == "${expected_total}" && "${main_records}" == 2 &&
+      "${worker_tids}" == "${CONCURRENCY}" ]]; then
+      printf '%s,%s,%s,%s,%s\n' "${generation}" "${ENVOY_PID}" "${total}" \
+        "${main_records}" "${worker_tids}" >>"${run_dir}/tls-role-evidence.csv"
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "TLS role mismatch for ${generation}: total=${total}, main=${main_records}, " \
+    "worker_tids=${worker_tids}" >&2
+  return 1
+}
+load_ready_schedule() {
+  local schedule="$1"
+  local expected_header='round,measured,start_offset_ms,normal_requests,round_duration_ms,recovery_latency_ms'
+  [[ -f "${schedule}" ]] || { echo "missing Ready schedule: ${schedule}" >&2; return 1; }
+  local header
+  IFS= read -r header <"${schedule}"
+  [[ "${header}" == "${expected_header}" ]] || {
+    echo "invalid Ready schedule header in ${schedule}" >&2; return 1;
+  }
+  mapfile -t READY_SCHEDULE_ROWS < <(tail -n +2 "${schedule}")
+  ((${#READY_SCHEDULE_ROWS[@]} > 0)) || { echo "Ready schedule has no rounds" >&2; return 1; }
+  READY_ROUND_SCAN_COUNTS=()
+
+  local expected_round=1 previous_offset=-1 saw_warmup=false saw_measured=false
+  local round measured offset requests duration latency extra expected_phase
+  local warmup_ms=$((WARMUP_SECONDS * 1000))
+  local total_ms=$(((WARMUP_SECONDS + DURATION_SECONDS) * 1000))
+  for row in "${READY_SCHEDULE_ROWS[@]}"; do
+    IFS=, read -r round measured offset requests duration latency extra <<<"${row}"
+    [[ -z "${extra:-}" ]] || { echo "Ready schedule row has extra fields: ${row}" >&2; return 1; }
+    for pair in "round:${round}" "offset:${offset}" "requests:${requests}" \
+      "duration:${duration}" "latency:${latency}"; do
+      [[ "${pair#*:}" =~ ^[0-9]+$ ]] || {
+        echo "Ready schedule has non-integer ${pair%%:*}: ${row}" >&2; return 1;
+      }
+    done
+    [[ "${round}" == "${expected_round}" ]] || {
+      echo "Ready schedule round gap: expected ${expected_round}, got ${round}" >&2; return 1;
+    }
+    (( offset > previous_offset && offset < total_ms )) || {
+      echo "Ready schedule offset is missing, unordered, or out of range: ${row}" >&2; return 1;
+    }
+    (( requests >= 1 && requests <= READY_SCAN_LIMIT )) || {
+      echo "Ready schedule scan count is out of range: ${row}" >&2; return 1;
+    }
+    (( duration >= 1 && latency >= 1000 )) || {
+      echo "Ready schedule duration/latency is invalid: ${row}" >&2; return 1;
+    }
+    expected_phase=false
+    (( offset >= warmup_ms )) && expected_phase=true
+    [[ "${measured}" == "${expected_phase}" ]] || {
+      echo "Ready schedule phase is misaligned with warmup boundary: ${row}" >&2; return 1;
+    }
+    [[ "${measured}" == true ]] && saw_measured=true || saw_warmup=true
+    READY_ROUND_SCAN_COUNTS[round]="${requests}"
+    expected_round=$((expected_round + 1))
+    previous_offset="${offset}"
+  done
+  [[ "${saw_warmup}" == true && "${saw_measured}" == true ]] || {
+    echo "Ready schedule must cover both warmup and measured phases" >&2; return 1;
+  }
+}
+
+load_ready_request_schedule() {
+  local schedule="$1"
+  local expected_header='round,request,start_offset_ms,guard_elapsed_ms,recovered'
+  [[ -f "${schedule}" ]] || {
+    echo "missing Ready request schedule: ${schedule}" >&2; return 1;
+  }
+  local header
+  IFS= read -r header <"${schedule}"
+  [[ "${header}" == "${expected_header}" ]] || {
+    echo "invalid Ready request schedule header in ${schedule}" >&2; return 1;
+  }
+  local rows
+  mapfile -t rows < <(tail -n +2 "${schedule}")
+  ((${#rows[@]} > 0)) || { echo "Ready request schedule has no rows" >&2; return 1; }
+  READY_REQUEST_OFFSETS=()
+  local expected_round=1 expected_request=1 previous_offset=0
+  local round request_index offset guard_elapsed recovered extra expected_count
+  for row in "${rows[@]}"; do
+    IFS=, read -r round request_index offset guard_elapsed recovered extra <<<"${row}"
+    [[ -z "${extra:-}" && "${round}" =~ ^[0-9]+$ && "${request_index}" =~ ^[0-9]+$ &&
+      "${offset}" =~ ^[0-9]+$ && "${guard_elapsed}" =~ ^[0-9]+$ ]] || {
+      echo "malformed Ready request schedule row: ${row}" >&2; return 1;
+    }
+    (( round == expected_round && request_index == expected_request )) || {
+      echo "Ready request schedule gap or misordering: ${row}" >&2; return 1;
+    }
+    expected_count="${READY_ROUND_SCAN_COUNTS[round]:-0}"
+    (( expected_count >= 1 && request_index <= expected_count &&
+      guard_elapsed >= READY_GUARD_WAIT_MS && offset > previous_offset )) || {
+      echo "Ready request schedule offset/count mismatch: ${row}" >&2; return 1;
+    }
+    if (( request_index == expected_count )); then
+      [[ "${recovered}" == true ]] || {
+        echo "Ready request schedule final scan did not recover: ${row}" >&2; return 1;
+      }
+      expected_round=$((expected_round + 1))
+      expected_request=1
+      previous_offset=0
+    else
+      [[ "${recovered}" == false ]] || {
+        echo "Ready request schedule recovered before final scan: ${row}" >&2; return 1;
+      }
+      expected_request=$((expected_request + 1))
+      previous_offset="${offset}"
+    fi
+    READY_REQUEST_OFFSETS["${round}:${request_index}"]="${offset}"
+  done
+  (( expected_round == ${#READY_SCHEDULE_ROWS[@]} + 1 && expected_request == 1 )) || {
+    echo "Ready request schedule ended before all rounds were covered" >&2; return 1;
+  }
+}
+
+load_initialization_schedule() {
+  local schedule="$1"
+  local expected_header='round,measured,start_offset_ms,normal_requests,round_duration_ms,recovery_latency_ms'
+  [[ -f "${schedule}" ]] || {
+    echo "missing initialization schedule: ${schedule}" >&2; return 1;
+  }
+  local header
+  IFS= read -r header <"${schedule}"
+  [[ "${header}" == "${expected_header}" ]] || {
+    echo "invalid initialization schedule header in ${schedule}" >&2; return 1;
+  }
+  mapfile -t INITIALIZATION_SCHEDULE_ROWS < <(tail -n +2 "${schedule}")
+  ((${#INITIALIZATION_SCHEDULE_ROWS[@]} > 0)) || {
+    echo "initialization schedule has no rounds" >&2; return 1;
+  }
+  INITIALIZATION_ROUND_SCAN_COUNTS=()
+
+  local expected_round=1 previous_offset=-1 saw_warmup=false saw_measured=false
+  local round measured offset requests duration latency extra expected_phase
+  local warmup_ms=$((WARMUP_SECONDS * 1000))
+  local total_ms=$(((WARMUP_SECONDS + DURATION_SECONDS) * 1000))
+  for row in "${INITIALIZATION_SCHEDULE_ROWS[@]}"; do
+    IFS=, read -r round measured offset requests duration latency extra <<<"${row}"
+    [[ -z "${extra:-}" ]] || {
+      echo "initialization schedule row has extra fields: ${row}" >&2; return 1;
+    }
+    for pair in "round:${round}" "offset:${offset}" "requests:${requests}" \
+      "duration:${duration}" "latency:${latency}"; do
+      [[ "${pair#*:}" =~ ^[0-9]+$ ]] || {
+        echo "initialization schedule has non-integer ${pair%%:*}: ${row}" >&2; return 1;
+      }
+    done
+    [[ "${round}" == "${expected_round}" ]] || {
+      echo "initialization schedule round gap: expected ${expected_round}, got ${round}" >&2
+      return 1
+    }
+    (( offset > previous_offset && offset < total_ms )) || {
+      echo "initialization schedule offset is missing, unordered, or out of range: ${row}" >&2
+      return 1
+    }
+    (( requests >= CONCURRENCY && requests <= READY_SCAN_LIMIT )) || {
+      echo "initialization schedule scan count is out of range: ${row}" >&2; return 1;
+    }
+    (( duration >= 1 && latency >= 1000 )) || {
+      echo "initialization schedule duration/latency is invalid: ${row}" >&2; return 1;
+    }
+    expected_phase=false
+    (( offset >= warmup_ms )) && expected_phase=true
+    [[ "${measured}" == "${expected_phase}" ]] || {
+      echo "initialization schedule phase is misaligned with warmup boundary: ${row}" >&2
+      return 1
+    }
+    [[ "${measured}" == true ]] && saw_measured=true || saw_warmup=true
+    INITIALIZATION_ROUND_SCAN_COUNTS[round]="${requests}"
+    expected_round=$((expected_round + 1))
+    previous_offset="${offset}"
+  done
+  [[ "${saw_warmup}" == true && "${saw_measured}" == true ]] || {
+    echo "initialization schedule must cover both warmup and measured phases" >&2; return 1;
+  }
+}
+
+load_initialization_request_schedule() {
+  local schedule="$1"
+  local expected_header='round,request,start_offset_ms,recovered_delta'
+  [[ -f "${schedule}" ]] || {
+    echo "missing initialization request schedule: ${schedule}" >&2; return 1;
+  }
+  local header
+  IFS= read -r header <"${schedule}"
+  [[ "${header}" == "${expected_header}" ]] || {
+    echo "invalid initialization request schedule header in ${schedule}" >&2; return 1;
+  }
+  local rows
+  mapfile -t rows < <(tail -n +2 "${schedule}")
+  ((${#rows[@]} > 0)) || {
+    echo "initialization request schedule has no rows" >&2; return 1;
+  }
+  INITIALIZATION_REQUEST_OFFSETS=()
+  local expected_round=1 expected_request=1 previous_offset=0 recovered_sum=0
+  local round request_index offset recovered_delta extra expected_count
+  for row in "${rows[@]}"; do
+    IFS=, read -r round request_index offset recovered_delta extra <<<"${row}"
+    [[ -z "${extra:-}" && "${round}" =~ ^[0-9]+$ && "${request_index}" =~ ^[0-9]+$ &&
+      "${offset}" =~ ^[0-9]+$ && "${recovered_delta}" =~ ^[0-9]+$ ]] || {
+      echo "malformed initialization request schedule row: ${row}" >&2; return 1;
+    }
+    (( round == expected_round && request_index == expected_request )) || {
+      echo "initialization request schedule gap or misordering: ${row}" >&2; return 1;
+    }
+    expected_count="${INITIALIZATION_ROUND_SCAN_COUNTS[round]:-0}"
+    (( expected_count >= CONCURRENCY && request_index <= expected_count && offset >= 1000 &&
+      offset > previous_offset && recovered_delta <= CONCURRENCY )) || {
+      echo "initialization request schedule offset/count mismatch: ${row}" >&2; return 1;
+    }
+    recovered_sum=$((recovered_sum + recovered_delta))
+    (( recovered_sum <= CONCURRENCY )) || {
+      echo "initialization request schedule recovered too many workers: ${row}" >&2; return 1;
+    }
+    INITIALIZATION_REQUEST_OFFSETS["${round}:${request_index}"]="${offset}"
+    if (( request_index == expected_count )); then
+      (( recovered_sum == CONCURRENCY )) || {
+        echo "initialization request schedule final scan did not recover every worker: ${row}" >&2
+        return 1
+      }
+      expected_round=$((expected_round + 1))
+      expected_request=1
+      previous_offset=0
+      recovered_sum=0
+    else
+      (( recovered_sum < CONCURRENCY )) || {
+        echo "initialization request schedule recovered before final scan: ${row}" >&2; return 1;
+      }
+      expected_request=$((expected_request + 1))
+      previous_offset="${offset}"
+    fi
+  done
+  (( expected_round == ${#INITIALIZATION_SCHEDULE_ROWS[@]} + 1 && expected_request == 1 )) || {
+    echo "initialization request schedule ended before all rounds were covered" >&2; return 1;
+  }
+}
+
+sample() {
+  local run_dir="$1" elapsed="$2"
+  local status="/proc/${ENVOY_PID}/status" rollup="/proc/${ENVOY_PID}/smaps_rollup"
+  local rss rss_anon threads pss dirty fd cpu heap
+  rss="$(awk '/VmRSS:/ {print $2}' "${status}")"
+  rss_anon="$(awk '/RssAnon:/ {print $2}' "${status}")"
+  threads="$(awk '/Threads:/ {print $2}' "${status}")"
+  pss="$(awk '/^Pss:/ {print $2}' "${rollup}")"
+  dirty="$(awk '/^Private_Dirty:/ {print $2}' "${rollup}")"
+  fd="$(find "/proc/${ENVOY_PID}/fd" -maxdepth 1 -type l | wc -l)"
+  cpu="$(awk '{print $14 + $15}' "/proc/${ENVOY_PID}/stat")"
+  heap="$(stat_value server.memory_heap_size -1)"
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    "${elapsed}" "${MEASURED_EVENTS}" "$(stat_value "${retryable_stat}")" \
+    "$(stat_value "${retry_stat}")" "$(stat_value "${recovered_stat}")" \
+    "$(stat_value "${crash_stat}")" "$(stat_value "${recover_stat}")" \
+    "$(stat_value "${uninitialized_stat}")" "$(stat_value "${active_stat}")" \
+    "$(stat_value server.memory_allocated)" "${heap}" "${rss}" "${rss_anon}" "${pss}" "${dirty}" \
+    "${fd}" "${threads}" "${cpu}" "${LAST_LATENCY_MS}" >>"${run_dir}/samples.csv"
+}
+
+do_event() {
+  local run_dir="$1" scenario="$2" control="$3" measured="$4"
+  EVENT_SEQUENCE=$((EVENT_SEQUENCE + 1))
+  local generation="${scenario}-${control}-${EVENT_SEQUENCE}"
+  local before after response_before retry_delta request_index recovery_delta
+  local round_start_ms recovery_end_ms round_end_ms recovery_latency_ms scan_requests
+  local request_start_offset_ms request_target_ms request_now_ms request_lag_ms recovery_changed
+  local ready_guard_anchor_ms ready_guard_elapsed_ms
+  local request_key
+  case "${scenario}:${control}" in
+    initialization:false)
+      round_start_ms="$(date +%s%3N)"
+      before="$(stat_value "${retryable_stat}")"
+      install_generation "${run_dir}" trap-once "${generation}" "${generation}"
+      wait_stat_at_least "${retryable_stat}" "$((before + CONCURRENCY))"
+      [[ "$(stat_value "${retryable_stat}")" == "$((before + CONCURRENCY))" ]] || {
+        echo "initialization round ${EVENT_SEQUENCE} did not fail exactly ${CONCURRENCY} workers" >&2
+        return 1
+      }
+      require_tls_roles "${run_dir}" "${generation}"
+      sleep 1.05
+      before="$(stat_value "${recovered_stat}")"
+      scan_requests=0
+      for request_index in $(seq 1 "${READY_SCAN_LIMIT}"); do
+        scan_requests="${request_index}"
+        request_start_offset_ms=$(($(date +%s%3N) - round_start_ms))
+        response_before="$(stat_value "${recovered_stat}")"
+        request "${run_dir}" "${generation}-${request_index}"
+        after="$(stat_value "${recovered_stat}")"
+        recovery_delta=$((after - response_before))
+        (( recovery_delta >= 0 && recovery_delta <= CONCURRENCY &&
+          after <= before + CONCURRENCY )) || {
+          echo "initialization round ${EVENT_SEQUENCE} recovery counter changed unexpectedly" >&2
+          return 1
+        }
+        if (( recovery_delta > 0 )); then
+          grep -qi '^x-plugin-marker: ready' "${run_dir}/last.headers"
+          grep -qi "^x-worker-init-generation: ${generation}" "${run_dir}/last.headers"
+        fi
+        printf '%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${request_index}" \
+          "${request_start_offset_ms}" "${recovery_delta}" \
+          >>"${run_dir}/initialization-requests.csv"
+        (( after == before + CONCURRENCY )) && break
+      done
+      after="$(stat_value "${recovered_stat}")"
+      [[ "${after}" == "$((before + CONCURRENCY))" ]] || {
+        echo "initialization round ${EVENT_SEQUENCE} exhausted ${READY_SCAN_LIMIT} requests " \
+          "before recovering every worker" >&2
+        return 1
+      }
+      recovery_end_ms="$(date +%s%3N)"
+      wait_stat_eq "${uninitialized_stat}" 0
+      wait_stat_eq "${active_stat}" "${EXPECTED_ACTIVE_STEADY}"
+      round_end_ms="$(date +%s%3N)"
+      recovery_latency_ms=$((recovery_end_ms - round_start_ms))
+      printf '%s,%s,%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${measured}" \
+        "${EVENT_START_OFFSET_MS}" "${scan_requests}" "$((round_end_ms - round_start_ms))" \
+        "${recovery_latency_ms}" >>"${run_dir}/initialization-schedule.csv"
+      if [[ "${measured}" == true ]]; then
+        MEASURED_EVENTS=$((MEASURED_EVENTS + after - before))
+      fi
+      ;;
+    initialization:true)
+      (( INITIALIZATION_REPLAY_SCAN_COUNT >= CONCURRENCY &&
+        INITIALIZATION_REPLAY_SCAN_COUNT <= READY_SCAN_LIMIT ))
+      round_start_ms="$(date +%s%3N)"
+      install_generation "${run_dir}" healthy "${generation}" "${generation}"
+      wait_log_generation "${run_dir}" "${generation}"
+      require_tls_roles "${run_dir}" "${generation}"
+      for request_index in $(seq 1 "${INITIALIZATION_REPLAY_SCAN_COUNT}"); do
+        request_key="${EVENT_SEQUENCE}:${request_index}"
+        request_start_offset_ms="${INITIALIZATION_REQUEST_OFFSETS[$request_key]:-}"
+        [[ "${request_start_offset_ms}" =~ ^[0-9]+$ ]] || {
+          echo "missing initialization request replay offset for " \
+            "${EVENT_SEQUENCE}:${request_index}" >&2
+          return 1
+        }
+        request_target_ms=$((round_start_ms + request_start_offset_ms))
+        request_now_ms="$(date +%s%3N)"
+        while (( request_now_ms < request_target_ms )); do
+          sleep 0.01
+          request_now_ms="$(date +%s%3N)"
+        done
+        request_lag_ms=$((request_now_ms - request_target_ms))
+        (( request_lag_ms <= MAX_REPLAY_LAG_MS )) || {
+          echo "initialization request replay ${EVENT_SEQUENCE}:${request_index} lag " \
+            "${request_lag_ms}ms exceeds ${MAX_REPLAY_LAG_MS}ms" >&2
+          return 1
+        }
+        printf '%s,%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${request_index}" \
+          "${request_start_offset_ms}" "$((request_now_ms - round_start_ms))" \
+          "${request_lag_ms}" >>"${run_dir}/initialization-request-replay.csv"
+        request "${run_dir}" "${generation}-${request_index}"
+        grep -qi '^x-plugin-marker: ready' "${run_dir}/last.headers"
+        grep -qi "^x-worker-init-generation: ${generation}" "${run_dir}/last.headers"
+      done
+      wait_stat_eq "${uninitialized_stat}" 0
+      wait_stat_eq "${active_stat}" "${EXPECTED_ACTIVE_STEADY}"
+      if [[ "${measured}" == true ]]; then
+        MEASURED_EVENTS=$((MEASURED_EVENTS + CONCURRENCY))
+      fi
+      ;;
+    ready:false)
+      round_start_ms="$(date +%s%3N)"
+      before="$(stat_value "${crash_stat}")"
+      request "${run_dir}" "ready-trap-${EVENT_SEQUENCE}" true
+      ready_guard_anchor_ms="$(date +%s%3N)"
+      wait_stat_at_least "${crash_stat}" "$((before + 1))"
+      [[ "$(stat_value "${crash_stat}")" == "$((before + 1))" ]]
+      # Crash observation is part of the guard wait, not additional serial delay. Anchoring after
+      # the trap response ensures every recovery request remains at least one second after crash.
+      wait_until_ms "$((ready_guard_anchor_ms + READY_GUARD_WAIT_MS))"
+      before="$(stat_value "${recover_stat}")"
+      response_before="${before}"
+      scan_requests=0
+      for request_index in $(seq 1 "${READY_SCAN_LIMIT}"); do
+        scan_requests="${request_index}"
+        request_now_ms="$(date +%s%3N)"
+        request_start_offset_ms=$((request_now_ms - round_start_ms))
+        ready_guard_elapsed_ms=$((request_now_ms - ready_guard_anchor_ms))
+        (( ready_guard_elapsed_ms >= READY_GUARD_WAIT_MS ))
+        request "${run_dir}" "ready-recover-${EVENT_SEQUENCE}-${request_index}"
+        after="$(stat_value "${recover_stat}")"
+        recovery_changed=false
+        if (( after > response_before )); then
+          recovery_changed=true
+          grep -qi '^x-plugin-marker: ready' "${run_dir}/last.headers"
+          grep -qi '^x-worker-init-generation: initial' "${run_dir}/last.headers"
+        fi
+        printf '%s,%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${request_index}" \
+          "${request_start_offset_ms}" "${ready_guard_elapsed_ms}" "${recovery_changed}" \
+          >>"${run_dir}/ready-requests.csv"
+        [[ "${recovery_changed}" == true ]] && break
+        # The request path is the only recovery trigger. Reuse its post-request value as the next
+        # baseline instead of adding another admin round trip before the following request.
+        response_before="${after}"
+      done
+      after="$(stat_value "${recover_stat}")"
+      [[ "${after}" == "$((before + 1))" ]]
+      recovery_end_ms="$(date +%s%3N)"
+      [[ "$(stat_value "${recover_error_stat}")" == 0 ]]
+      [[ "$(stat_value "${retry_stat}")" == "${INIT_RETRY_BASELINE}" ]]
+      [[ "$(stat_value "${recovered_stat}")" == "${INIT_RECOVERED_BASELINE}" ]]
+      wait_stat_eq "${uninitialized_stat}" 0
+      wait_active_at_most "${ACTIVE_BASELINE}"
+      round_end_ms="$(date +%s%3N)"
+      recovery_latency_ms=$((recovery_end_ms - round_start_ms))
+      printf '%s,%s,%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${measured}" \
+        "${EVENT_START_OFFSET_MS}" "${scan_requests}" "$((round_end_ms - round_start_ms))" \
+        "${recovery_latency_ms}" >>"${run_dir}/ready-schedule.csv"
+      if [[ "${measured}" == true ]]; then MEASURED_EVENTS=$((MEASURED_EVENTS + 1)); fi
+      ;;
+    ready:true)
+      (( READY_REPLAY_SCAN_COUNT >= 1 && READY_REPLAY_SCAN_COUNT <= READY_SCAN_LIMIT ))
+      round_start_ms="$(date +%s%3N)"
+      request "${run_dir}" "ready-control-a-${EVENT_SEQUENCE}"
+      ready_guard_anchor_ms="$(date +%s%3N)"
+      wait_until_ms "$((ready_guard_anchor_ms + READY_GUARD_WAIT_MS))"
+      for request_index in $(seq 1 "${READY_REPLAY_SCAN_COUNT}"); do
+        request_key="${EVENT_SEQUENCE}:${request_index}"
+        request_start_offset_ms="${READY_REQUEST_OFFSETS[$request_key]:-}"
+        [[ "${request_start_offset_ms}" =~ ^[0-9]+$ ]] || {
+          echo "missing Ready request replay offset for ${EVENT_SEQUENCE}:${request_index}" >&2
+          return 1
+        }
+        request_target_ms=$((round_start_ms + request_start_offset_ms))
+        request_now_ms="$(date +%s%3N)"
+        while (( request_now_ms < request_target_ms )); do
+          sleep 0.01
+          request_now_ms="$(date +%s%3N)"
+        done
+        request_lag_ms=$((request_now_ms - request_target_ms))
+        (( request_lag_ms <= MAX_REPLAY_LAG_MS )) || {
+          echo "Ready request replay ${EVENT_SEQUENCE}:${request_index} lag ${request_lag_ms}ms" >&2
+          return 1
+        }
+        printf '%s,%s,%s,%s,%s\n' "${EVENT_SEQUENCE}" "${request_index}" \
+          "${request_start_offset_ms}" "$((request_now_ms - round_start_ms))" \
+          "${request_lag_ms}" >>"${run_dir}/ready-request-replay.csv"
+        request "${run_dir}" "ready-control-b-${EVENT_SEQUENCE}-${request_index}"
+        grep -qi '^x-plugin-marker: ready' "${run_dir}/last.headers"
+        grep -qi '^x-worker-init-generation: initial' "${run_dir}/last.headers"
+      done
+      wait_stat_eq "${uninitialized_stat}" 0
+      wait_active_at_most "${ACTIVE_BASELINE}"
+      if [[ "${measured}" == true ]]; then MEASURED_EVENTS=$((MEASURED_EVENTS + 1)); fi
+      ;;
+    persistent:false)
+      before="$(stat_value "${retry_stat}")"
+      for request_index in $(seq 1 "${REQUESTS_PER_EVENT}"); do
+        request "${run_dir}" "persistent-${EVENT_SEQUENCE}-${request_index}"
+      done
+      after="$(stat_value "${retry_stat}")"
+      retry_delta=$((after - before))
+      (( retry_delta >= 0 && retry_delta <= CONCURRENCY ))
+      printf '%s,%s,%s,%s,%s\n' "$(date +%s%3N)" "${EVENT_SEQUENCE}" "${before}" \
+        "${after}" "${retry_delta}" >>"${run_dir}/attempt-rate.csv"
+      wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+      wait_active_at_most "${ACTIVE_BASELINE}"
+      if [[ "${measured}" == true ]]; then
+        MEASURED_EVENTS=$((MEASURED_EVENTS + retry_delta))
+      fi
+      ;;
+    persistent:true)
+      for request_index in $(seq 1 "${REQUESTS_PER_EVENT}"); do
+        request "${run_dir}" "persistent-control-${EVENT_SEQUENCE}-${request_index}"
+      done
+      wait_stat_eq "${uninitialized_stat}" 0
+      wait_active_at_most "${ACTIVE_BASELINE}"
+      if [[ "${measured}" == true ]]; then
+        MEASURED_EVENTS=$((MEASURED_EVENTS + CONCURRENCY))
+      fi
+      ;;
+  esac
+}
+
+run_one() {
+  local scenario="$1" control="$2" repetition="$3"
+  local label="${scenario}-rep${repetition}"
+  [[ "${control}" == true ]] && label="${label}-healthy-control"
+  local run_dir="${WORKDIR}/${label}"
+  mkdir -p "${run_dir}"
+  if [[ "${scenario}" == ready || "${scenario}" == initialization ]]; then
+    if [[ "${control}" == true ]]; then
+      if [[ "${scenario}" == ready ]]; then
+        load_ready_schedule "${WORKDIR}/ready-rep${repetition}/ready-schedule.csv"
+        load_ready_request_schedule "${WORKDIR}/ready-rep${repetition}/ready-requests.csv"
+      else
+        load_initialization_schedule \
+          "${WORKDIR}/initialization-rep${repetition}/initialization-schedule.csv"
+        load_initialization_request_schedule \
+          "${WORKDIR}/initialization-rep${repetition}/initialization-requests.csv"
+      fi
+      printf '%s\n' \
+        'round,measured,scheduled_offset_ms,actual_offset_ms,replay_lag_ms,normal_requests' \
+        >"${run_dir}/${scenario}-replay.csv"
+      printf '%s\n' 'round,request,scheduled_offset_ms,actual_offset_ms,replay_lag_ms' \
+        >"${run_dir}/${scenario}-request-replay.csv"
+    else
+      printf '%s\n' \
+        'round,measured,start_offset_ms,normal_requests,round_duration_ms,recovery_latency_ms' \
+        >"${run_dir}/${scenario}-schedule.csv"
+      if [[ "${scenario}" == ready ]]; then
+        printf '%s\n' 'round,request,start_offset_ms,guard_elapsed_ms,recovered' \
+          >"${run_dir}/ready-requests.csv"
+      else
+        printf '%s\n' 'round,request,start_offset_ms,recovered_delta' \
+          >"${run_dir}/initialization-requests.csv"
+      fi
+    fi
+  fi
+  EVENT_SEQUENCE=0; MEASURED_EVENTS=0; LAST_LATENCY_MS=0
+  local initial_mode=healthy
+  [[ "${scenario}" == persistent && "${control}" == false ]] && initial_mode=trap-always
+  install_generation "${run_dir}" "${initial_mode}" initial "${label}-initial"
+  sed -e "s#__ADMIN_PORT__#${ADMIN_PORT}#g" -e "s#__UPSTREAM_PORT__#${UPSTREAM_PORT}#g" \
+    -e "s#__WORKDIR__#${run_dir}#g" "${ECDS_DIR}/config.yaml.template" >"${run_dir}/config.yaml"
+  sed -e "s#__LISTENER_PORT__#${LISTENER_PORT}#g" -e "s#__WORKDIR__#${run_dir}#g" \
+    "${ECDS_DIR}/lds.yaml.template" >"${run_dir}/lds.yaml"
+  "${ENVOY_BIN}" --mode validate -c "${run_dir}/config.yaml" --log-level error \
+    >"${run_dir}/validate.log" 2>&1
+  UPSTREAM_PORT="${UPSTREAM_PORT}" python3 "${PARENT_DIR}/upstream_server.py" \
+    >"${run_dir}/upstream.log" 2>&1 &
+  UPSTREAM_PID=$!
+  for _ in $(seq 1 80); do
+    curl --fail --silent --max-time 1 "http://127.0.0.1:${UPSTREAM_PORT}/" >/dev/null 2>&1 && break
+    sleep 0.25
+  done
+  "${ENVOY_BIN}" -c "${run_dir}/config.yaml" --concurrency "${CONCURRENCY}" \
+    --base-id "${BASE_ID}" --file-flush-interval-msec 100 \
+    --log-level warn --component-log-level wasm:debug \
+    --log-path "${run_dir}/envoy.log" >"${run_dir}/console.log" 2>&1 &
+  ENVOY_PID=$!
+  for _ in $(seq 1 120); do
+    if kill -0 "${ENVOY_PID}" >/dev/null 2>&1 &&
+      curl --fail --silent --max-time 1 "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null 2>&1; then break; fi
+    sleep 0.25
+  done
+  curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${ADMIN_PORT}/ready" >/dev/null
+
+  printf '%s\n' 'elapsed_seconds,events,retryable_failures,init_retries,init_recovered,crashes,ready_recovered,uninitialized,active,server_memory_allocated,server_memory_heap_size,rss_kb,rss_anon_kb,pss_kb,private_dirty_kb,fd_count,thread_count,cpu_ticks,last_event_latency_ms' \
+    >"${run_dir}/samples.csv"
+  printf '%s\n' 'timestamp_ms,round,retry_before,retry_after,actual_attempts' \
+    >"${run_dir}/attempt-rate.csv"
+  printf '%s\n' 'generation,main_thread_tid,plugin_start_records,main_thread_records,worker_tids' \
+    >"${run_dir}/tls-role-evidence.csv"
+  if [[ "${scenario}" == persistent && "${control}" == false ]]; then
+    wait_stat_eq "${uninitialized_stat}" "${CONCURRENCY}"
+  else
+    wait_stat_eq "${uninitialized_stat}" 0
+  fi
+  require_tls_roles "${run_dir}" initial
+  request "${run_dir}" initial-baseline
+  ACTIVE_BASELINE="$(stat_value "${active_stat}")"
+  (( ACTIVE_BASELINE >= 1 ))
+  EXPECTED_ACTIVE_STEADY="${ACTIVE_BASELINE}"
+  EXPECTED_UNINITIALIZED_STEADY=0
+  if [[ "${scenario}" == initialization && "${control}" == false ]]; then
+    (( ACTIVE_BASELINE >= 2 ))
+    EXPECTED_ACTIVE_STEADY=$((ACTIVE_BASELINE - 1))
+  elif [[ "${scenario}" == persistent && "${control}" == false ]]; then
+    EXPECTED_UNINITIALIZED_STEADY="${CONCURRENCY}"
+  fi
+  INIT_RETRY_BASELINE="$(stat_value "${retry_stat}")"
+  INIT_RECOVERED_BASELINE="$(stat_value "${recovered_stat}")"
+  local start_ms measure_start_ms end_ms next_event_ms next_sample_ms now_ms measured elapsed
+  local row round scheduled_offset scan_requests scheduled_duration scheduled_latency extra
+  local target_ms actual_offset replay_lag
+  start_ms="$(date +%s%3N)"
+  measure_start_ms=$((start_ms + WARMUP_SECONDS * 1000))
+  end_ms=$((measure_start_ms + DURATION_SECONDS * 1000))
+  next_event_ms="${start_ms}"
+  next_sample_ms="${measure_start_ms}"
+  if [[ ( "${scenario}" == ready || "${scenario}" == initialization ) &&
+    "${control}" == true ]]; then
+    local schedule_rows_name="${scenario^^}_SCHEDULE_ROWS"
+    local -n scheduled_rows="${schedule_rows_name}"
+    for row in "${scheduled_rows[@]}"; do
+      IFS=, read -r round measured scheduled_offset scan_requests scheduled_duration \
+        scheduled_latency extra <<<"${row}"
+      [[ "${round}" == "$((EVENT_SEQUENCE + 1))" && -z "${extra:-}" ]]
+      target_ms=$((start_ms + scheduled_offset))
+      now_ms="$(date +%s%3N)"
+      while (( now_ms < target_ms )); do
+        if (( now_ms >= next_sample_ms && next_sample_ms < end_ms )); then
+          elapsed=$(((now_ms - measure_start_ms) / 1000))
+          (( elapsed >= 0 && elapsed < DURATION_SECONDS )) && sample "${run_dir}" "${elapsed}"
+          next_sample_ms=$((next_sample_ms + SAMPLE_INTERVAL_SECONDS * 1000))
+        fi
+        sleep 0.05
+        now_ms="$(date +%s%3N)"
+      done
+      actual_offset=$((now_ms - start_ms))
+      replay_lag=$((actual_offset - scheduled_offset))
+      (( replay_lag >= 0 && replay_lag <= MAX_REPLAY_LAG_MS )) || {
+        echo "${scenario} replay round ${round} lag ${replay_lag}ms exceeds " \
+          "${MAX_REPLAY_LAG_MS}ms" >&2
+        return 1
+      }
+      EVENT_START_OFFSET_MS="${scheduled_offset}"
+      if [[ "${scenario}" == ready ]]; then
+        READY_REPLAY_SCAN_COUNT="${scan_requests}"
+      else
+        INITIALIZATION_REPLAY_SCAN_COUNT="${scan_requests}"
+      fi
+      do_event "${run_dir}" "${scenario}" "${control}" "${measured}"
+      printf '%s,%s,%s,%s,%s,%s\n' "${round}" "${measured}" "${scheduled_offset}" \
+        "${actual_offset}" "${replay_lag}" "${scan_requests}" \
+        >>"${run_dir}/${scenario}-replay.csv"
+      now_ms="$(date +%s%3N)"
+      if (( now_ms >= next_sample_ms && next_sample_ms < end_ms )); then
+        elapsed=$(((now_ms - measure_start_ms) / 1000))
+        (( elapsed >= 0 && elapsed < DURATION_SECONDS )) && sample "${run_dir}" "${elapsed}"
+        next_sample_ms=$((next_sample_ms + SAMPLE_INTERVAL_SECONDS * 1000))
+      fi
+    done
+    [[ "${EVENT_SEQUENCE}" == "${#scheduled_rows[@]}" ]]
+    now_ms="$(date +%s%3N)"
+    while (( now_ms < end_ms )); do
+      if (( now_ms >= next_sample_ms )); then
+        elapsed=$(((now_ms - measure_start_ms) / 1000))
+        (( elapsed < DURATION_SECONDS )) && sample "${run_dir}" "${elapsed}"
+        next_sample_ms=$((next_sample_ms + SAMPLE_INTERVAL_SECONDS * 1000))
+      fi
+      sleep 0.05
+      now_ms="$(date +%s%3N)"
+    done
+  else
+    while true; do
+      now_ms="$(date +%s%3N)"
+      (( now_ms >= end_ms )) && break
+      measured=false
+      (( now_ms >= measure_start_ms )) && measured=true
+      if (( now_ms >= next_event_ms )); then
+        EVENT_START_OFFSET_MS=$((now_ms - start_ms))
+        do_event "${run_dir}" "${scenario}" "${control}" "${measured}"
+        now_ms="$(date +%s%3N)"
+        next_event_ms=$((next_event_ms + EVENT_INTERVAL_MS))
+        if (( next_event_ms < now_ms )); then next_event_ms="${now_ms}"; fi
+      fi
+      if (( now_ms >= next_sample_ms )); then
+        elapsed=$(((now_ms - measure_start_ms) / 1000))
+        (( elapsed < DURATION_SECONDS )) && sample "${run_dir}" "${elapsed}"
+        next_sample_ms=$((next_sample_ms + SAMPLE_INTERVAL_SECONDS * 1000))
+      fi
+      sleep 0.05
+    done
+    if [[ "${scenario}" == ready ]]; then
+      load_ready_schedule "${run_dir}/ready-schedule.csv"
+      load_ready_request_schedule "${run_dir}/ready-requests.csv"
+    elif [[ "${scenario}" == initialization ]]; then
+      load_initialization_schedule "${run_dir}/initialization-schedule.csv"
+      load_initialization_request_schedule "${run_dir}/initialization-requests.csv"
+    fi
+  fi
+  # Periodic samples intentionally stop before the measured boundary. Record one terminal sample
+  # for the final event count without adding it to any fixed resource window.
+  sample "${run_dir}" "${DURATION_SECONDS}"
+  local minimum
+  case "${scenario}" in
+    initialization) minimum="${MIN_INITIALIZATION_RECOVERIES}" ;;
+    ready) minimum="${MIN_READY_RECOVERIES}" ;;
+    persistent) minimum="${MIN_PERSISTENT_ATTEMPTS}" ;;
+  esac
+  python3 "${SCRIPT_DIR}/analyze.py" --input "${run_dir}/samples.csv" \
+    --output "${run_dir}/windows.csv" --window-seconds "${WINDOW_SECONDS}" \
+    --minimum-events "${minimum}" --duration-seconds "${DURATION_SECONDS}" \
+    --sample-interval-seconds "${SAMPLE_INTERVAL_SECONDS}" 2>&1 |
+    tee "${run_dir}/analysis.txt"
+  awk -F, -v duration="${DURATION_SECONDS}" -v scenario="${scenario}" \
+    -v expected_active="${EXPECTED_ACTIVE_STEADY}" \
+    -v expected_uninitialized="${EXPECTED_UNINITIALIZED_STEADY}" '
+      NR == 1 { next }
+      $1 < duration {
+        rows++
+        if ($8 != expected_uninitialized || $9 != expected_active) {
+          printf "%s steady-state contract failed: %s\n", scenario, $0 > "/dev/stderr"
+          failed = 1
+        }
+      }
+      END { if (rows == 0 || failed) exit 1 }
+    ' "${run_dir}/samples.csv"
+  {
+    echo "scenario=${scenario}"
+    echo "healthy_control=${control}"
+    echo "repetition=${repetition}"
+    echo "minimum_events=${minimum}"
+    echo "observed_events=${MEASURED_EVENTS}"
+    echo "run_active_baseline=${ACTIVE_BASELINE}"
+    echo "expected_active_steady=${EXPECTED_ACTIVE_STEADY}"
+    echo "expected_worker_uninitialized_steady=${EXPECTED_UNINITIALIZED_STEADY}"
+    echo "config_sha256=$(sha256sum "${run_dir}/config.yaml" | awk '{print $1}')"
+    echo "tls_role_evidence_sha256=$(sha256sum "${run_dir}/tls-role-evidence.csv" | awk '{print $1}')"
+    if [[ "${scenario}" == ready || "${scenario}" == initialization ]]; then
+      if [[ "${control}" == false ]]; then
+        echo "${scenario}_schedule_sha256=$(sha256sum \
+          "${run_dir}/${scenario}-schedule.csv" | awk '{print $1}')"
+        echo "${scenario}_requests_sha256=$(sha256sum \
+          "${run_dir}/${scenario}-requests.csv" | awk '{print $1}')"
+      else
+        echo "source_${scenario}_schedule_sha256=$(sha256sum \
+          "${WORKDIR}/${scenario}-rep${repetition}/${scenario}-schedule.csv" | awk '{print $1}')"
+        echo "source_${scenario}_requests_sha256=$(sha256sum \
+          "${WORKDIR}/${scenario}-rep${repetition}/${scenario}-requests.csv" | awk '{print $1}')"
+        echo "${scenario}_replay_sha256=$(sha256sum \
+          "${run_dir}/${scenario}-replay.csv" | awk '{print $1}')"
+        echo "${scenario}_request_replay_sha256=$(sha256sum \
+          "${run_dir}/${scenario}-request-replay.csv" | awk '{print $1}')"
+      fi
+    fi
+  } >"${run_dir}/evidence.txt"
+  kill "${ENVOY_PID}" >/dev/null 2>&1 || true
+  wait "${ENVOY_PID}" >/dev/null 2>&1 || true
+  ENVOY_PID=""
+  grep -q '~Wasm 0 remaining active' "${run_dir}/console.log"
+  kill "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  wait "${UPSTREAM_PID}" >/dev/null 2>&1 || true
+  UPSTREAM_PID=""
+}
+
+if [[ -n "${READY_SCHEDULE_VALIDATE_ONLY_DIR}" ]]; then
+  READY_SCHEDULE_VALIDATE_ONLY_DIR="$(realpath -m "${READY_SCHEDULE_VALIDATE_ONLY_DIR}")"
+  load_ready_schedule "${READY_SCHEDULE_VALIDATE_ONLY_DIR}/ready-schedule.csv"
+  load_ready_request_schedule "${READY_SCHEDULE_VALIDATE_ONLY_DIR}/ready-requests.csv"
+  echo "PASS Ready schedule validation: ${#READY_SCHEDULE_ROWS[@]} rounds"
+  trap - EXIT
+  exit 0
+fi
+
+if [[ -n "${INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR}" ]]; then
+  INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR="$(realpath -m \
+    "${INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR}")"
+  load_initialization_schedule \
+    "${INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR}/initialization-schedule.csv"
+  load_initialization_request_schedule \
+    "${INITIALIZATION_SCHEDULE_VALIDATE_ONLY_DIR}/initialization-requests.csv"
+  echo "PASS initialization schedule validation: ${#INITIALIZATION_SCHEDULE_ROWS[@]} rounds"
+  trap - EXIT
+  exit 0
+fi
+
+scenarios=("${SCENARIO}")
+[[ "${SCENARIO}" == all ]] && scenarios=(initialization ready persistent)
+for scenario in "${scenarios[@]}"; do
+  for repetition in $(seq 1 "${REPETITIONS}"); do
+    run_one "${scenario}" false "${repetition}"
+    run_one "${scenario}" true "${repetition}"
+    actual_dir="${WORKDIR}/${scenario}-rep${repetition}"
+    control_dir="${WORKDIR}/${scenario}-rep${repetition}-healthy-control"
+    python3 "${SCRIPT_DIR}/compare.py" --actual "${actual_dir}/windows.csv" \
+      --control "${control_dir}/windows.csv" --output "${actual_dir}/paired-comparison.csv" 2>&1 |
+      tee "${actual_dir}/paired-analysis.txt"
+  done
+done
+cleanup_case
+trap - EXIT
+echo "campaign: ${cat_manifest}"
+echo PASS

--- a/verification/examples/wasm-worker-init-failure/upstream_server.py
+++ b/verification/examples/wasm-worker-init-failure/upstream_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import http.server
+import os
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        plugin_marker = self.headers.get("x-worker-init-plugin", "absent")
+        print(f"path={self.path} plugin={plugin_marker}", flush=True)
+        body = f"upstream=reached plugin={plugin_marker}\n".encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/plain")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("x-upstream-marker", "reached")
+        self.send_header("x-plugin-marker", plugin_marker)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+port = int(os.environ.get("UPSTREAM_PORT", "3084"))
+http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/verification/examples/wasm-worker-init-failure/wasm/go.mod
+++ b/verification/examples/wasm-worker-init-failure/wasm/go.mod
@@ -1,0 +1,7 @@
+module envoy-verification/wasm-worker-init-failure
+
+go 1.24.1
+
+toolchain go1.24.5
+
+require github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20251103120604-77e9cce339d2

--- a/verification/examples/wasm-worker-init-failure/wasm/go.sum
+++ b/verification/examples/wasm-worker-init-failure/wasm/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20251103120604-77e9cce339d2 h1:NY33OrWCJJ+DFiLc+lsBY4Ywor2Ik61ssk6qkGF8Ypo=
+github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20251103120604-77e9cce339d2/go.mod h1:tRI2LfMudSkKHhyv1uex3BWzcice2s/l8Ah8axporfA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkWkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75rkeocQhZ8V7i1bVxVN5oS7DTKGE=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1TtnT/8w6g2J0U8KiO9eWF5lg=

--- a/verification/examples/wasm-worker-init-failure/wasm/main.go
+++ b/verification/examples/wasm-worker-init-failure/wasm/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func main() {}
+
+func init() {
+	proxywasm.SetPluginContext(func(contextID uint32) types.PluginContext {
+		return &workerInitPluginContext{contextID: contextID}
+	})
+}
+
+type pluginConfig struct {
+	Mode        string `json:"mode"`
+	RunID       string `json:"run_id"`
+	WorkerCount int    `json:"worker_count"`
+	Generation  string `json:"generation"`
+}
+
+type workerInitPluginContext struct {
+	types.DefaultPluginContext
+	contextID  uint32
+	generation string
+}
+
+func (ctx *workerInitPluginContext) OnPluginStart(int) types.OnPluginStartStatus {
+	configuration, err := proxywasm.GetPluginConfiguration()
+	if err != nil {
+		proxywasm.LogCriticalf("worker-init-repro: read configuration failed: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+
+	var config pluginConfig
+	if err := json.Unmarshal(configuration, &config); err != nil {
+		proxywasm.LogCriticalf("worker-init-repro: decode configuration failed: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+	if config.RunID == "" {
+		proxywasm.LogCritical("worker-init-repro: run_id must not be empty")
+		return types.OnPluginStartStatusFailed
+	}
+	if config.WorkerCount < 1 {
+		proxywasm.LogCriticalf("worker-init-repro: worker_count must be positive, got %d",
+			config.WorkerCount)
+		return types.OnPluginStartStatusFailed
+	}
+	if config.Generation == "" {
+		proxywasm.LogCritical("worker-init-repro: generation must not be empty")
+		return types.OnPluginStartStatusFailed
+	}
+	ctx.generation = config.Generation
+
+	attempt, err := nextAttempt("worker-init-repro/" + config.RunID)
+	if err != nil {
+		proxywasm.LogCriticalf("worker-init-repro: shared attempt update failed: %v", err)
+		return types.OnPluginStartStatusFailed
+	}
+	proxywasm.LogWarnf("worker-init-repro: plugin start mode=%s attempt=%d context_id=%d generation=%s run_id=%s worker_count=%d",
+		config.Mode, attempt, ctx.contextID, config.Generation, config.RunID, config.WorkerCount)
+
+	// Attempt one is the createWasm canary. Main and worker TLS callbacks race after that, so the
+	// injector deliberately covers every one of those callbacks without assigning roles by ordinal.
+	if attempt == 1 {
+		return types.OnPluginStartStatusOK
+	}
+
+	switch config.Mode {
+	case "configure-reject":
+		return types.OnPluginStartStatusFailed
+	case "trap-once":
+		if attempt <= 2+config.WorkerCount {
+			panic("worker-init-repro: intentional one-shot worker initialization trap")
+		}
+	case "trap-always":
+		panic("worker-init-repro: intentional persistent worker initialization trap")
+	case "healthy":
+		// No failure injection.
+	default:
+		proxywasm.LogCriticalf("worker-init-repro: unsupported mode %q", config.Mode)
+		return types.OnPluginStartStatusFailed
+	}
+	return types.OnPluginStartStatusOK
+}
+
+func (ctx *workerInitPluginContext) NewHttpContext(uint32) types.HttpContext {
+	return &workerInitHTTPContext{generation: ctx.generation}
+}
+
+type workerInitHTTPContext struct {
+	types.DefaultHttpContext
+	generation string
+}
+
+func (ctx *workerInitHTTPContext) OnHttpRequestHeaders(int, bool) types.Action {
+	trap, _ := proxywasm.GetHttpRequestHeader("x-worker-init-request-trap")
+	if trap == "true" {
+		proxywasm.LogCriticalf("worker-init-repro: intentional request trap generation=%s",
+			ctx.generation)
+		panic("worker-init-repro: intentional request-stage trap")
+	}
+	_ = proxywasm.AddHttpRequestHeader("x-worker-init-plugin", "ready")
+	return types.ActionContinue
+}
+
+func (ctx *workerInitHTTPContext) OnHttpResponseHeaders(int, bool) types.Action {
+	_ = proxywasm.AddHttpResponseHeader("x-worker-init-generation", ctx.generation)
+	return types.ActionContinue
+}
+
+func nextAttempt(key string) (int, error) {
+	for retry := 0; retry < 32; retry++ {
+		value, cas, err := proxywasm.GetSharedData(key)
+		if errors.Is(err, types.ErrorStatusNotFound) {
+			if err := proxywasm.SetSharedData(key, []byte("1"), 0); err != nil {
+				return 0, err
+			}
+			return 1, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		current, err := strconv.Atoi(string(value))
+		if err != nil {
+			return 0, fmt.Errorf("invalid shared attempt %q: %w", value, err)
+		}
+		next := current + 1
+		err = proxywasm.SetSharedData(key, []byte(strconv.Itoa(next)), cas)
+		if errors.Is(err, types.ErrorStatusCasMismatch) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		return next, nil
+	}
+	return 0, fmt.Errorf("shared attempt CAS did not converge")
+}


### PR DESCRIPTION
### Implementation Rationale

Backport the exact functional scope of internal Envoy MR 29133492 so a worker-local Wasm initialization failure does not poison a healthy base VM, request traffic can recover a failed worker behind the existing one-second guard, and proactive reclaim can roll an active generation while bounding live generations to current plus one old generation.

The approved owning-dispatcher prerequisite is included because the MR regression requires base Wasm destruction to occur on its dispatcher thread. Internal ALIMESH guards are mapped to HIGRESS, and proxy-wasm-cpp-host is pinned to current Higress master d9c558753df6781388e36e0d51adc98c0b6835a0 with the matching archive SHA.

### Source and adaptation

- Source MR: 29133492, squash 03d4f659b316d5207dc5ca1f89f421a7d7e8da46.
- Approved prerequisite semantics: 68a31b92a18455d64a00f91d316f55fa8d2a8ced.
- Host pin: d9c558753df6781388e36e0d51adc98c0b6835a0; tree 9cdf1a9ed40d945f94af5c8ea458892c383b818e.
- Host provenance harness reads proxy_wasm_cpp_host.version from Higress http_archive metadata.
- No unrelated wasm_filter_test formatting changes are included.

### Verification

- Targeted Bazel suite passed for common Wasm, HTTP Wasm config, and HTTP Wasm filter coverage, including same-vm-key clone failure isolation, owning-dispatcher deletion, request recovery guard, rolling two-generation bound, and reclaim timer behavior.
- Final review-only amendments on 1.27 were INFO-to-DEBUG logging, Higress provenance parser/docs, and removal of formatting-only churn.
- Shell syntax, Python AST, gofmt, Envoy formatter for changed production/test code, and final diff checks pass.
- Independent amended-head review: P0=0, P1=0, P2=0.